### PR TITLE
Ignore local dev tooling artifacts (node, markdownlint, ..)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 *.pdf
 *.svg
 !/source/images/*.svg
+node_modules
+.vscode/
+.nvmrc
+.markdownlint.json
+package.json
+package-lock.json


### PR DESCRIPTION
## Title
Ignore local development tooling artifacts

## Summary
Add `.gitignore` entries to exclude local development tooling files that are not part of the GEISA specification or build system.

This change is intended to prevent accidental commits of environment-specific artifacts while keeping the repository aligned with its current tooling model.

## Changes
- Ignore local runtime/tooling configuration:
  - `.nvmrc`
  - `.markdownlint.json`
- Ignore local Node-based tooling artifacts:
  - `package.json`
  - `package-lock.json`

The repository has operated without Node or specific linters for some time now, and don't want them accidentally added into the project - at least at this time.  These additions basically just keep us safe environmentally.  If we want to introduce Node-based tooling or specific linter/config formally into the project later, we can revisit.

## Scope
- No impact to specification content
- No impact to build or documentation generation
- No runtime or API changes

## Notes
- This is a non-functional change and should be safe for all contributors regardless of local dev environment