### PR TITLE
Add /etc/geisa/mqtt.conf

### DIFF
--- a/source/api/architecture.rst
+++ b/source/api/architecture.rst
@@ -111,8 +111,16 @@ how to connect to the broker from data contained in a locally generated
 configuration file.
 
 For GEISA LEE |geisa-lee-tux|, this information SHALL be available at the
-well-known location ``/etc/geisa/config.binpb`` within the Application
+well-known location ``/etc/geisa/mqtt.conf`` within the Application
 container environment.
+
+.. code-block:: console
+
+        $ cat /etc/geisa/mqtt.conf
+        HOST=localhost
+        PORT=1883
+        USERID=myuserid
+        PASSWORD=mypassword
 
 For GEISA VEE |geisa-vee-cloud|, this information SHALL be made available to
 the Application by the platform. The specific mechanism by which it is exposed

--- a/source/lee/app-isolation.rst
+++ b/source/lee/app-isolation.rst
@@ -105,7 +105,7 @@ API Control
 
 Access to the GEISA API is controlled via MQTT permissions.  The platform will
 assign a userid and password (provided to the application in its unique
-``/etc/geisa/config.binpb`` file) that the application will use to connect to
+``/etc/geisa/mqtt.conf`` file) that the application will use to connect to
 the message bus.  That user will be restricted according to the permissions in
 the application manifest.  Please see :doc:`/api` and :doc:`/adm/manifests` for
 additional details.
@@ -133,8 +133,8 @@ manifest.
 Based on the permissions specified in the manifest, the platform creates the
 necessary MQTT user for the application, granting that user access to the
 necessary APIs allowed in the manifest.  It stores this the application's user
-credentials in ``/platform/apps/geisa-app-1/config/etc/geisa/config.binpb`` or
-in a ``/etc/geisa/config.pb`` file in an appropriate image file, stored in the
+credentials in ``/platform/apps/geisa-app-1/config/etc/geisa/mqtt.conf`` or
+in a ``/etc/geisa/mqtt.conf`` file in an appropriate image file, stored in the
 ``/platform/apps/geisa-app-1`` directory.
 
 To launch the application the platform will mount each of the required file


### PR DESCRIPTION
Removed /etc/geisa/config.binpb which was a binary protobuf file and replaced with the Linux convention of human readable configuration files, /etc/geisa/mqtt.conf.