### PR TITLE
Direct IP socket access and clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ system, and ensure the `drawio` command is available on `PATH`.
 For Linux, use the official draw.io Desktop package for your distribution
 (`.deb`, `.rpm`, or AppImage), or another trusted system package source. If
 using an AppImage, create a wrapper or symlink named `drawio` somewhere in
-`PATH`.  Information on the draw.io Desktop Package may be found
-[here](https://www.drawio.com/doc/faq/offline) .
+`PATH`.  Information on the
+[draw.io Desktop Package](https://www.drawio.com/doc/faq/offline) may be
+found in the draw.io offline FAQ.
 
 For example, on Ubuntu or another Debian-based distribution, download the
 official draw.io Desktop `.deb` package, then install it with:

--- a/source/adm/manifests.rst
+++ b/source/adm/manifests.rst
@@ -102,6 +102,13 @@ GEISA vendor manifests SHALL include:
   Application messaging is provided through the API and does not require direct
   access to a network interface.
 
+.. Note::
+
+   Requests for IP socket communication in a vendor manifest are subject to
+   operator approval in the deployment manifest. Operators may approve,
+   narrow, replace, or deny requested destination classes, endpoints, ports,
+   and volume limits according to deployment policy.
+
 - External Dependencies
 
     - GEISA applications should be as self-contained as possible, with all

--- a/source/api/networking.rst
+++ b/source/api/networking.rst
@@ -246,7 +246,7 @@ monthly volume limit.
 
 An application developer MUST define volume limits per destination class in
 their Vendor Application Manifest.  These limits may be overridden by the
-operator at deployment time when converting the Application Vendor Manifest
+operator at deployment time when converting the Vendor Application Manifest
 into a Deployment Manifest.
 
 These volume limits are specified as a per day (24 hour period) limit in

--- a/source/api/networking.rst
+++ b/source/api/networking.rst
@@ -245,7 +245,7 @@ whereas a cellular connection would be metered in order to keep the device under
 monthly volume limit.
 
 An application developer MUST define volume limits per destination class in
-their Application Vendor Manifest.  These limits may be overridden by the
+their Vendor Application Manifest.  These limits may be overridden by the
 operator at deployment time when converting the Application Vendor Manifest
 into a Deployment Manifest.
 

--- a/source/api/networking.rst
+++ b/source/api/networking.rst
@@ -18,6 +18,14 @@ Off-Device Communication
 GEISA allows applications to make use of 2 types of off-device communications:
 Message based, and IP socket based.
 
+GEISA distinguishes between platform-mediated message-based communication
+and application-managed IP socket communication. These are separate
+communication mechanisms. IP socket communication is not a transport
+selection option within GEISA app-message request and response payloads.
+Applications that require both mechanisms must request both in their
+manifest, and platforms enforce each according to the approved deployment
+policy.
+
 
 Message-based via LwM2M
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,6 +48,33 @@ For upstream messages, the queue contents may be long-lived due to delivery dela
 or network outages.  The messages in the queue SHALL be persistent across device
 reboots, power cycles, or application restarts, and if undeliverable beyond a
 timeout period a failure status is reported to the sender.
+
+Message queue persistence, retention, retry behavior, and recovery pacing
+are platform-managed behaviors subject to operator policy. Platforms
+SHOULD avoid creating a burst of delayed traffic when connectivity is
+restored. Appropriate mechanisms may include message expiration, priority
+handling, backoff, rate limiting, queue limits, or other
+platform-controlled delivery controls.
+
+A message-specific time-to-live value, when present, indicates the
+sender's requested maximum useful lifetime for that message. The platform
+MAY apply an implementation-defined maximum queued-message retention
+period and SHOULD expire the message when the applicable time-to-live or
+retention period is reached.
+
+This version of the specification does not define an interoperable
+operator override mechanism for storm conditions, network congestion, FAN
+outages, or other traffic management events. Such controls may exist as
+platform-specific or operator-specific capabilities and may be defined in
+a future version of this specification.
+
+This version of the specification does not mandate fallback or transfer of
+queued messages across destination classes or communication mechanisms.
+For example, a platform is not required to transfer queued message-based
+communication to an IP socket communication path, or to transfer failed IP
+socket communication to message-based communication. Applications that
+require cross-mechanism fallback are responsible for implementing that
+behavior within the permissions approved by the deployment policy.
 
 For downstream messages, the queue contents are usually short-lived if the
 application is running.  If an application is not running, or does not acknoledge
@@ -75,6 +110,22 @@ Once a network interface is online, the Application may use outbound-initiated
 AF_INET/AF_INET6 sockets from within the container environment to reach the
 specified endpoints.
 
+Approval of IP socket communication does not imply unmanaged or
+application-selected network reachability. The System Operator remains
+authoritative for which destination classes, endpoints, protocols, ports,
+and volumes are allowed. Platform implementations MAY satisfy approved IP
+socket communication using direct routing, NAT, firewall rules,
+forwarding, transparent proxies, shared upstream connections, or other
+platform-controlled mechanisms, provided the Application can use standard
+socket APIs from within its execution environment and the approved policy
+is enforced.
+
+Where a platform satisfies approved IP socket communication through
+proxying, NAT, forwarding, or shared upstream connectivity, the Application
+and operator remain responsible for the applicable application-layer
+security and trust behavior. See Security considerations below.
+
+
 Inbound connections towards the Application are only supported for the local
 destination class defined below and disallowed from other destination classes.
 
@@ -82,9 +133,9 @@ destination class defined below and disallowed from other destination classes.
 
   Support for IP socket communication is NOT REQUIRED by a GEISA device; however
   certain applications may REQUIRE it to function and would not be compatible
-  with those devices.  Applications can be designed to require IP socket
-  communication or if not available, fall back in a degraded functionality
-  mode to message-based communication.
+  with those devices.  Applications can be designed to require IP socket 
+  communication or, if it is not available, fall back to message-based 
+  communication functionality.
 
   Additionally, not all destination classes are REQUIRED by a GEISA device. An
   operator or device manufacturer may only support a subset depending on
@@ -126,10 +177,10 @@ Other network interfaces that may be available (but out of scope of
 Destination Classes
 ^^^^^^^^^^^^^^^^^^^
 
-The device may have zero, one, or multiple interfaces online at any given time.
-Applications are not required to know these details but instead only need to
-know if their desired endpoints are reachable and what volume limits are in
-place.
+The device may have zero, one, or multiple interfaces online at any given
+time. Applications are not required to know these details but instead only
+need to know if their desired endpoints are accessible under the approved
+deployment policy and what volume limits are in place.
 
 Each endpoint an application defines falls into one of these categories:
 
@@ -153,10 +204,12 @@ and would need a network status indicator for each class separately.  For
 example, it may communicate with both Internet Endpoints as well as Local
 Endpoints.
 
-Applications may report statistics and logs to the operating environment for
-troubleshooting and logging.  For example, if the operating environment has
-reported that Internet Endpoints should be reachable but the Application cannot
-reach them, it may report this error.
+Applications may observe a mismatch between reported network state and their
+own communication attempts. This version of the GEISA specification does not 
+define a dedicated application-to-platform diagnostic reporting mechanism 
+at this time.  Implementations MAY expose troubleshooting, logging, or diagnostic
+reporting through implementation-specific mechanisms or through future GEISA
+status, logging, or messaging extensions.
 
 
 Volume Limits
@@ -171,23 +224,33 @@ An application developer MUST define volume limits per destination class in thei
 Application Vendor Manifest.  These limits may be overridden by the operator at deployment
 time when converting the Application Vendor Manifest into a Deployment Manifest.
 
-These volume limits are specified as a per day (24 hour period) limit in bytes.
-Both transmit and receive data counts toward the application's limit.  The operator
-may define a daily rollover mechanism, and a reset period (ex: day of the month).
-GEISA does not define if or how header and encapsulation bytes count towards
-volume limits.
+These volume limits are specified as a per day (24 hour period) limit in
+bytes. For interoperability, application-visible volume accounting is based
+on application payload bytes. For IP socket communication, this is measured
+at the application socket boundary. For message-based communication, this
+is measured at the GEISA app-message payload boundary. Both transmit and
+receive application payload bytes count toward the application's limit.
 
-The application obtains the remaining volume limits and when the next reset occurs
-via :doc:`/api/status`.
+Operators may account for expected protocol, security, encapsulation,
+tunnel, or lower-layer overhead when setting limits. The platform MAY
+separately measure or estimate interface-level bytes, including protocol
+and lower-layer overhead, for operator visibility, network planning,
+analysis, audit, and subsequent adjustment of limits.
 
-If an application exhausts its volume quota for one or more destination classes,
-it will be sent a network state update with the volume field set to *zero* for
-those classes.  When this condition is cleared (on the next day or reset period),
-the application will be sent another network status update returning the volume
-field to *metered*
+The operator may define a daily rollover mechanism and a reset period (ex:
+day of the month). The application obtains the remaining volume limits and
+when the next reset occurs via :doc:`/api/status`.
 
-Volume limits do not apply to destination classes when the volume field set to
-*unlimited*.
+If an application exhausts its metered volume quota for one or more
+destination classes, the policy for those classes remains *metered* and
+the remaining metered byte count is reported as zero until the next reset
+or operator adjustment. Exhaustion of a metered quota does not change the
+policy to *zero*.
+
+The *zero* policy indicates that the Application currently has no usable
+allocation for that destination class, such as where access is not approved
+by deployment policy. Volume limits do not apply to destination classes
+when the policy is *unlimited*.
 
 
 Security considerations
@@ -202,6 +265,18 @@ For IP socket based communications, the application is responsible for encryptio
 and authentication of data passed between the device and its endpoints where
 needed.
 
+Applications MUST NOT assume that approved IP socket communication provides
+the same security, queuing, retry, or store-and-forward behavior as
+GEISA message-based communication unless those behaviors are explicitly
+provided by the application protocol or deployment environment.
+
+When a platform uses proxying or shared upstream connectivity, application
+layer security remains the responsibility of the relevant communication
+design. A network-layer proxy, NAT, or tunnel can preserve end-to-end
+application TLS. If a platform or operator service terminates,
+rewrites, or re-originates application-layer security, that behavior must
+be explicitly supported by the application, its configured trust material,
+and the operator's deployment policy.
 
 Connectivity
 ^^^^^^^^^^^^
@@ -226,6 +301,13 @@ routing between these components.
 The operating environment MUST provide a local lo interface within the container
 environment for each application. The local lo interface must be up and configured
 with both 127.0.0.1 and ::1 addresses.
+
+The apparent address, route, or connection path visible to an Application
+inside its container environment is not required to correspond one-to-one
+with the physical interface, upstream session, or operator network path
+used by the platform. Applications should treat the socket interface as
+the approved local execution-environment abstraction and rely on Platform
+and App Status for communication availability and quota state.
 
 
 Policy Rules

--- a/source/api/networking.rst
+++ b/source/api/networking.rst
@@ -20,11 +20,14 @@ Message based, and IP socket based.
 
 GEISA distinguishes between platform-mediated message-based communication
 and application-managed IP socket communication. These are separate
-communication mechanisms. IP socket communication is not a transport
-selection option within GEISA app-message request and response payloads.
-Applications that require both mechanisms must request both in their
-manifest, and platforms enforce each according to the approved deployment
-policy.
+communication mechanisms. Applications do not use GEISA app-message
+request and response payloads to perform IP socket communication. For
+ADM-conformant platforms, app-message transport uses the GEISA ADM LwM2M over
+CoAP path, carried by platform-controlled IP communication outside of the
+application execution environment. Applications remain unaware of those ADM
+transport details.  Applications that require both mechanisms must request both
+in their manifest, and platforms enforce each according to the approved 
+deployment policy.
 
 
 Message-based via LwM2M
@@ -49,38 +52,47 @@ or network outages.  The messages in the queue SHALL be persistent across device
 reboots, power cycles, or application restarts, and if undeliverable beyond a
 timeout period a failure status is reported to the sender.
 
-Message queue persistence, retention, retry behavior, and recovery pacing
-are platform-managed behaviors subject to operator policy. Platforms
-SHOULD avoid creating a burst of delayed traffic when connectivity is
-restored. Appropriate mechanisms may include message expiration, priority
-handling, backoff, rate limiting, queue limits, or other
-platform-controlled delivery controls.
+.. note::
+
+   Message queue persistence, retention, retry behavior, and recovery pacing
+   are platform-managed behaviors subject to operator policy. This version of
+   the specification does not define interoperable configuration mechanisms for
+   these behaviors. Future versions may define standard configuration and
+   observability mechanisms for platform-managed message queues.
+
+Platforms SHOULD avoid creating a burst of delayed traffic when connectivity
+is restored. Appropriate mechanisms may include message expiration, priority
+handling, backoff, rate limiting, queue limits, or other platform-controlled
+delivery controls.
 
 A message-specific time-to-live value, when present, indicates the
 sender's requested maximum useful lifetime for that message. The platform
 MAY apply an implementation-defined maximum queued-message retention
-period and SHOULD expire the message when the applicable time-to-live or
-retention period is reached.
+period and SHOULD expire the message when either the applicable time-to-live
+or retention period is reached.
 
-This version of the specification does not define an interoperable
-operator override mechanism for storm conditions, network congestion, FAN
-outages, or other traffic management events. Such controls may exist as
-platform-specific or operator-specific capabilities and may be defined in
-a future version of this specification.
+.. note::
+
+   This version of the specification does not define an interoperable operator
+   override mechanism for storm conditions, network congestion, FAN outages, or
+   other traffic management events. Such controls may exist as
+   platform-specific or operator-specific capabilities and may be defined in a
+   future version of this specification.
 
 This version of the specification does not mandate fallback or transfer of
 queued messages across destination classes or communication mechanisms.
 For example, a platform is not required to transfer queued message-based
-communication to an IP socket communication path, or to transfer failed IP
-socket communication to message-based communication. Applications that
-require cross-mechanism fallback are responsible for implementing that
-behavior within the permissions approved by the deployment policy.
+communication to an application IP socket communication path, or to
+transfer failed application IP socket communication to message-based
+communication. Applications that require cross-mechanism fallback are
+responsible for implementing that behavior within the permissions approved
+by the deployment policy.
 
 For downstream messages, the queue contents are usually short-lived if the
-application is running.  If an application is not running, or does not acknoledge
-the message delivery over the message bus the :doc:`/adm` is still responsible
-for queuing these messages and if undeliverable beyond a timeout period a failure
-status is reported to the sender.
+application is running. If an application is not running, or does not
+acknowledge message delivery over the message bus, the :doc:`/adm` is still
+responsible for queuing these messages and, if undeliverable beyond a timeout
+period, reporting a failure status to the sender.
 
 If an application is uninstalled while its messages are in the queue, a delivery
 failure status SHALL be sent back upstream for each queued downstream message,
@@ -100,8 +112,8 @@ IP socket based to local devices, private clouds, or public clouds
 Applications can also make use of traditional IP socket based real-time
 communications on devices equipped with cellular, Wi-Fi, or other IP connectivity.
 Applications MUST specify the endpoints they need to communicate to (IP/Port)
-in their Application Deployment Manifest so that those policies can be approved by operators
-and implemented in the platform using firewall rules.
+in their Application Deployment Manifest so that those policies can be approved
+ by operators and implemented in the platform using firewall rules.
 
 Applications MUST also specify the expected volume of data per day per
 destination class.
@@ -120,26 +132,37 @@ platform-controlled mechanisms, provided the Application can use standard
 socket APIs from within its execution environment and the approved policy
 is enforced.
 
-Where a platform satisfies approved IP socket communication through
-proxying, NAT, forwarding, or shared upstream connectivity, the Application
-and operator remain responsible for the applicable application-layer
-security and trust behavior. See Security considerations below.
-
+Approved IP socket communication may be satisfied through proxying, NAT,
+forwarding, or shared upstream connectivity. Regardless of the platform
+mechanism used, the Application remains responsible for its application-layer
+security behavior. The operator remains responsible for the deployment policy,
+operator-managed trust configuration, and operation of operator-managed
+platform and EMS components. See Security considerations below.
 
 Inbound connections towards the Application are only supported for the local
 destination class defined below and disallowed from other destination classes.
 
 .. note::
 
-  Support for IP socket communication is NOT REQUIRED by a GEISA device; however
-  certain applications may REQUIRE it to function and would not be compatible
-  with those devices.  Applications can be designed to require IP socket 
-  communication or, if it is not available, fall back to message-based 
+  Application-visible IP socket communication from within the Application
+  execution environment is NOT REQUIRED by every GEISA device. ADM-conformant
+  platforms still require IP connectivity for the ADM LwM2M over CoAP path, but
+  that platform-managed IP connectivity is distinct from Application-managed IP
+  socket access. Applications can be designed to require IP socket
+  communication or, if it is not available, fall back to message-based
   communication functionality.
 
   Additionally, not all destination classes are REQUIRED by a GEISA device. An
   operator or device manufacturer may only support a subset depending on
-  capabilities, deployment architecture, or security policy.
+  capabilities, deployment architecture, or security policy. The availability
+  of an approved application IP communication path is not guaranteed.
+  Applications may encounter intermittent or prolonged outages, or may run on
+  devices where some or all destination classes are not provisioned.
+  Applications approved for IP socket communication SHOULD be designed to
+  handle these conditions, operate in a degraded mode where appropriate, avoid
+  producing excessive alarms or logs, and fall back to message-based
+  communication only when that behavior is implemented by the application and
+  allowed by deployment policy.
 
 
 Interface Types
@@ -197,7 +220,8 @@ Network State
 ^^^^^^^^^^^^^
 
 For each destination class, applications have a network state that informs the
-application if and what volume of communication is available as described in :doc:`status`.
+application if and what volume of communication is available as described in
+:doc:`status`.
 
 An application can request communication with more than one class of endpoint
 and would need a network status indicator for each class separately.  For
@@ -205,9 +229,9 @@ example, it may communicate with both Internet Endpoints as well as Local
 Endpoints.
 
 Applications may observe a mismatch between reported network state and their
-own communication attempts. This version of the GEISA specification does not 
-define a dedicated application-to-platform diagnostic reporting mechanism 
-at this time.  Implementations MAY expose troubleshooting, logging, or diagnostic
+own communication attempts. This version of the GEISA specification does not
+define a dedicated application-to-platform diagnostic reporting mechanism.
+Implementations MAY expose troubleshooting, logging, or diagnostic
 reporting through implementation-specific mechanisms or through future GEISA
 status, logging, or messaging extensions.
 
@@ -220,9 +244,10 @@ transports the data.  A Home Wi-Fi network would normally be considered unlimite
 whereas a cellular connection would be metered in order to keep the device under a
 monthly volume limit.
 
-An application developer MUST define volume limits per destination class in their
-Application Vendor Manifest.  These limits may be overridden by the operator at deployment
-time when converting the Application Vendor Manifest into a Deployment Manifest.
+An application developer MUST define volume limits per destination class in
+their Application Vendor Manifest.  These limits may be overridden by the
+operator at deployment time when converting the Application Vendor Manifest
+into a Deployment Manifest.
 
 These volume limits are specified as a per day (24 hour period) limit in
 bytes. For interoperability, application-visible volume accounting is based
@@ -237,9 +262,11 @@ separately measure or estimate interface-level bytes, including protocol
 and lower-layer overhead, for operator visibility, network planning,
 analysis, audit, and subsequent adjustment of limits.
 
-The operator may define a daily rollover mechanism and a reset period (ex:
-day of the month). The application obtains the remaining volume limits and
-when the next reset occurs via :doc:`/api/status`.
+The daily rollover mechanism and reset period are deployment and platform
+policy. This version of the specification does not define an
+application-visible transaction for configuring those policy values. The
+application obtains the remaining volume limits and the next reset time via
+:doc:`/api/status`.
 
 If an application exhausts its metered volume quota for one or more
 destination classes, the policy for those classes remains *metered* and
@@ -270,13 +297,23 @@ the same security, queuing, retry, or store-and-forward behavior as
 GEISA message-based communication unless those behaviors are explicitly
 provided by the application protocol or deployment environment.
 
-When a platform uses proxying or shared upstream connectivity, application
-layer security remains the responsibility of the relevant communication
-design. A network-layer proxy, NAT, or tunnel can preserve end-to-end
-application TLS. If a platform or operator service terminates,
-rewrites, or re-originates application-layer security, that behavior must
-be explicitly supported by the application, its configured trust material,
-and the operator's deployment policy.
+When a platform uses proxying, forwarding, NAT, tunneling, or shared
+upstream connectivity, application-layer security remains the
+responsibility of the relevant communication design. Network-layer
+mediation can preserve end-to-end application TLS or mTLS semantics.
+Applications MAY use certificate pinning, client authentication, or other
+application-layer trust mechanisms where supported by their protocol.
+
+.. note::
+
+  This version of the specification does not define an interoperable mechanism
+  for an Application vendor to declare whether TLS inspection, explicit
+  proxying, or operator-mediated re-origination of application-layer security is
+  supported. Operators and platform implementations that use such mechanisms
+  are responsible for ensuring that the behavior is compatible with the
+  Application, its configured trust material, and the deployment policy. A
+  future version may define manifest fields or policy controls for this
+  behavior.
 
 Connectivity
 ^^^^^^^^^^^^
@@ -367,7 +404,7 @@ between devices, the Application Manifest cannot list destination/source IP
 addresses for policy rules, but instead only protocol/port and multicast groups.
 
 An application requesting inbound access in its manifest requires that the
-platform create that inbound mapping from the approprate local interface (such
+platform create that inbound mapping from the appropriate local interface (such
 as a WiFi interface) into the application container environment.  When
 requesting a port mapping, both IPv4 and IPv6 MUST be mapped if the local
 interface supports both.
@@ -375,7 +412,7 @@ interface supports both.
 Many common local device protocols use multicast or broadcast for discovery and
 registration.  Applications SHOULD be able to both send to IP multicast groups
 and register IP multicast groups for receipt.  If specified in the application
-manifiest, the platform will register those addresses on the approprate local
+manifest, the platform will register those addresses on the appropriate local
 interface and forward received packets that match both the multicast/broadcast
 address and the inbound protocol/port into the application container environment.
 

--- a/source/operations.rst
+++ b/source/operations.rst
@@ -221,7 +221,7 @@ trust establishment, registration, and subsequent lifecycle management.
    Reference device onboarding and management establishment flow
    retained for comparison and discussion.
 
-Additional detailed device onboarding workflows and requirements may be added 
+Additional detailed device onboarding workflows and requirements may be added
 in a future revision of the specification.
 
 Application Approval and Deployment Overview
@@ -263,6 +263,11 @@ outage behavior, inbound exposure, fleet network capacity, and operational
 visibility. Inbound IP socket communication generally presents higher
 operational and security risk than outbound-initiated communication and
 may be limited to local endpoint use cases or denied by operator policy.
+This version of the specification does not define interoperable support for
+application-hosted listeners reachable from upstream operator networks or for
+peer-to-peer application communication over the AMI network. Those use cases
+may be considered in a future version if driven by operator or application
+requirements.
 
 Platform-originated reporting should provide timely operator visibility
 into denied access attempts, quota limits reached, unexpected egress attempts,

--- a/source/operations.rst
+++ b/source/operations.rst
@@ -241,6 +241,36 @@ remain under operator control.
 Additional detailed application approval and deployment workflows and 
 requirements may be added in a future revision of the specification.
 
+Off-Device Communication Approval
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Applications may request message-based communication, IP socket
+communication, or both. Operationally, these requests are inputs to the
+deployment decision and do not entitle an Application to unmanaged network
+access. The System Operator determines whether requested communication is
+approved for the target deployment environment.
+
+Direct IP socket communication should be reviewed as a distinct operational
+and security decision. Operators may choose to deny direct IP communication
+by default, approve it only for selected applications or destination
+classes, restrict it to operator-controlled endpoints, or require the
+platform to mediate approved traffic through routing, NAT, firewalling,
+forwarding, transparent proxying, or shared upstream connections.
+
+The approval review should consider endpoint ownership, protocol and port
+scope, certificate and trust behavior, expected data volume, retry behavior,
+outage behavior, inbound exposure, fleet network capacity, and operational
+visibility. Inbound IP socket communication generally presents higher
+operational and security risk than outbound-initiated communication and
+may be limited to local endpoint use cases or denied by operator policy.
+
+Platform-originated reporting should provide timely operator visibility
+into denied access attempts, quota limits reached, unexpected egress attempts,
+proxy or forwarding failures, and other communication policy violations.
+The reporting mechanism may be defined by ADM/EMS behavior, platform event
+reporting, event logs, app accounting, or future GEISA operational event
+extensions.
+
 Application Activation and Runtime Visibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary

Clarifies the GEISA spec around off-device communication, especially the boundary between platform-mediated message-based communication and application-managed IP socket communication.

## Changes

- Clarified that message-based communication and IP socket communication are separate mechanisms
- Stated that IP socket communication is not a transport selection option inside app-message request/response payloads
- Added deployment-manifest approval language for requested IP socket communication
- Clarified that operators may approve, narrow, replace, or deny requested destination classes, endpoints, ports, and volume limits
- Added queue-management guidance for message-based communication:
  - persistence and retry are platform-managed
  - platforms should avoid traffic bursts after connectivity restoration
  - TTL/retention behavior may be subject to platform/operator policy
  - cross-mechanism fallback is not mandated
- Clarified that approved IP socket communication may be implemented through direct routing, NAT, firewalling, forwarding, transparent proxying, shared upstream connections, or similar platform-controlled mechanisms
- Minor cleanups around volume-limit language:
  - app-visible accounting is based on application payload bytes
  - IP socket communication is measured at the application socket boundary
  - message-based communication is measured at the GEISA app-message payload boundary
  - protocol/security/lower-layer overhead may still be measured separately for operator visibility and planning
- Clarified metered quota exhaustion behavior:
  - exhausted metered allocations remain `metered` with zero remaining bytes
  - exhaustion does not change policy to `zero`
  - `zero` means no currently usable allocation for that destination class
- Added operations guidance for off-device communication approval and review
- Cleaned up draw.io link README lint issue

