### PR TITLE
Cleanup of AppAccounting IDs and descriptions.  First pass on mandato…

### DIFF
--- a/source/adm/oma/3602.xml
+++ b/source/adm/oma/3602.xml
@@ -27,7 +27,8 @@ See https://github.com/OpenMobileAlliance/app_messaging
 
 LEGAL DISCLAIMER
 
-Copyright 2019-2026 Open Mobile Alliance.
+Copyright 2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -58,22 +59,28 @@ POSSIBILITY OF SUCH DAMAGE.
 The above license is used as a license under copyright only. Please
 reference the OMA IPR Policy for patent licensing terms:
 https://www.omaspecworks.org/about/intellectual-property-rights/
-
 -->
 <LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M-v1_1.xsd">
   <Object ObjectType="MODefinition">
     <Name>AppAccounting</Name>
     <Description1><![CDATA[
-This LwM2M Object provides operations-facing application accounting and policy summary state for an application or application accounting scope. It exposes current-period usage counters, quotas and limits, throttle, block, or disabled state, selected enforcement evidence, operator or EMS/ADM action resources, and application or accounting-scope operational monitoring.
+    This LwM2M Object provides operations-facing application accounting and policy summary state for an application, application instance, or application accounting scope. It exposes bounded-window usage counters, limits and remaining budget where applicable, current quota and enforcement state, selected summary evidence, operator or EMS/ADM action resources, and application or accounting-scope operational accounting summaries.
+    Each AppAccounting object instance represents accounting for one application, application instance, accounting scope, and accounting window. The primary AppAccounting instance for an application/application-instance/accounting scope SHOULD represent the current accounting period. Additional AppAccounting object instances MAY expose bounded secondary windows or views, such as a previous completed period, configured collection period, rolling window, lifetime view, or operator-defined view. Secondary instances MUST be distinguishable by Accounting Window Type, Period Start Time, Period End Time, Scope Label where available, and AppID.
 
-Multiple AppAccounting object instances may exist for the same AppID, Accounting Class, and Accounting Scope to expose different accounting windows such as configured collection period, daily, since-reboot, rolling-window, lifetime, or operator-defined accounting.
+    This object is intended to expose bounded accounting windows, not unbounded accounting history. If GEISA APIs expose previous-period or yesterday accounting values, the platform MUST provide a means to retrieve those values. The platform MAY expose the previous completed period as a secondary AppAccounting object instance, or MAY provide the values through an EMS/ADM API, retained accounting record, Event Log record, or other platform-defined history mechanism.
+    Usage counters remain relevant even when the effective policy is unlimited; unlimited policy means no active quota exhaustion is expected, not that observed usage is irrelevant.
+    Quota State summarizes quota or budget availability. Throttle State summarizes whether the application accounting scope is actively constrained, throttled, blocked, disabled, or not constrained. Detailed behavioral application issues, platform-detected anomalies, configuration-state problems, platform health signals, policy evaluation details, and durable history are surfaced through platform messaging, platform monitoring or configuration resources, the Event Log object, EMS/ADM records, or other platform-defined retention mechanisms where supported.
+    This object may expose selected summary state derived from those sources for ease of operations monitoring, but it is not the definitive source for all application behavioral detail.
 
-Usage counters remain relevant even when the effective policy is unlimited; unlimited policy means no active quota exhaustion is expected, not that observed usage is irrelevant.
-
-Detailed behavoral application issues, platform-detected anomalies, configuration-state problems, platform health signals, and policy evaluation details are surfaced through platform messaging, platform monitoring or configuration resources, and durable event, log, or message history where supported.
-
-This object may expose selected summary state derived from those sources for ease of operations monitoring, but it is not the definitive source for all application behavioral detail.
-]]></Description1>
+    GEISA Resource IDs are grouped to leave room for future expansion:
+    0..9 identify scope and accounting window
+    10..19 expose usage counters
+    20..29 expose limits and remaining budget
+    30..39 expose quota and enforcement state
+    40..49 expose selected evidence
+    50..59 expose operator or EMS/ADM actions
+    4050 is reserved for the shared GEISA AppID resource
+    ]]></Description1>
     <ObjectID>3602</ObjectID>
     <ObjectURN>urn:oma:lwm2m:ext:3602</ObjectURN>
     <LWM2MVersion>1.1</LWM2MVersion>
@@ -82,137 +89,18 @@ This object may expose selected summary state derived from those sources for eas
     <Mandatory>Optional</Mandatory>
     <Resources>
       <Item ID="0">
-        <Name>Collection Period</Name>
-        <Operations>RW</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
-        <Type>String</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-A string in RFC 5545 Recurrence Rule (RRule) format defining the configured recurring accounting period when the Accounting Window Type represents a configured or recurring period (e.g., "RRULE:FREQ=MINUTELY;INTERVAL=60").
-
-Counters are interpreted within the active collection period and reset or roll over according to the accounting policy or profile.
-
-For non-recurring windows such as Since reboot or Lifetime, Period Start Time identifies the beginning of the accounting window and Next Reset Time may be unavailable.
-]]></Description>
-      </Item>
-      <Item ID="1">
-        <Name>Maximum Bytes</Name>
-        <Operations>RW</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Hard limit maximum number of bytes allowed per collection period for the application or accounting scope represented by this object instance.
-
-Above this limit, the platform may initiate throttling or blocking without waiting for a Server command, subject to local policy and implementation support.
-]]></Description>
-      </Item>
-      <Item ID="2">
-        <Name>TX Bytes</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Number of bytes transmitted so far during the current collection period for the accounting class and scope represented by this object instance.
-TX bytes represent usage emitted by the application or accounting scope.
-]]></Description>
-      </Item>
-      <Item ID="3">
-        <Name>RX Bytes</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Number of bytes received so far during the current collection period for the accounting class and scope represented by this object instance.
-RX bytes represent usage directed to the application or accounting scope when an authoritative inbound accounting source exists.
-]]></Description>
-      </Item>
-      <Item ID="4">
-        <Name>Total Bytes</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Total number of bytes transmitted plus received so far during the current collection period for the accounting class and scope represented by this object instance.
-Total bytes are derived from TX Bytes plus RX Bytes for the modeled accounting scope.
-]]></Description>
-      </Item>
-      <Item ID="5">
-        <Name>TX Packets</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Number of packets transmitted so far during the current collection period for the accounting class and scope represented by this object instance. Packet counters are meaningful only for profiles or accounting classes with authoritative packet-level accounting.
-]]></Description>
-      </Item>
-      <Item ID="6">
-        <Name>RX Packets</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Number of packets received so far during the current collection period for the accounting class and scope represented by this object instance. Packet counters are meaningful only for profiles or accounting classes with authoritative packet-level accounting.
-]]></Description>
-      </Item>
-      <Item ID="7">
-        <Name>Start Throttling</Name>
-        <Operations>E</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type/>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Apply constrained or rate-limited behavior for the application or accounting scope represented by this object instance.
-Platforms may deny this operation or leave it unsupported according to operator policy, authorization, implementation profile, or lack of an enforcement path.
-]]></Description>
-      </Item>
-      <Item ID="8">
-        <Name>Stop Throttling</Name>
-        <Operations>E</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type/>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Remove explicit throttling for the application or accounting scope represented by this object instance.
-Platforms may deny this operation or leave it unsupported according to operator policy, authorization, implementation profile, or lack of an enforcement path.
-]]></Description>
-      </Item>
-      <Item ID="9">
         <Name>Software Instance</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
+        <Mandatory>Mandatory</Mandatory>
         <Type>Objlnk</Type>
         <RangeEnumeration/>
         <Units/>
-        <Description><![CDATA[
-Optional object link to a related LwM2M Software Management /9 instance for the installed application package associated with this accounting instance, when available. This link is secondary and does not replace resource 4050 AppID as the primary local application identity anchor for this object.
-]]></Description>
+        <Description><![CDATA[Link to the LwM2M Software Management object instance (/9) associated with the application or application instance represented by this accounting row.
+
+This link allows accounting state to be correlated with app package, install, activation, and lifecycle information. When /9 is used for GEISA app management, this resource MUST identify the relevant /9 Software Management instance.]]></Description>
       </Item>
-      <Item ID="10">
+      <Item ID="1">
         <Name>Accounting Class</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -233,29 +121,25 @@ Accounting class whose counters, limits, quota state, throttle, block, disabled 
 Platform or application status messages, events, logs, and platform monitoring records may inform this summary state, but they are not a separate accounting class unless a GEISA-defined or operator-defined accounting policy explicitly assigns them to one.
 ]]></Description>
       </Item>
-      <Item ID="11">
+      <Item ID="2">
         <Name>Accounting Scope</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
+        <Mandatory>Mandatory</Mandatory>
         <Type>Integer</Type>
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
-        <Description><![CDATA[
-Boundary or scope for accounting associated with resource 4050 AppID.
+        <Description><![CDATA[Identifies the scope of accounting represented by this object instance within the Accounting Class.
 
+The scope defines the boundary being counted, such as platform-mediated app messages, local application communication, or another GEISA-defined or operator-defined accounting scope.
 0 = Unspecified
-1 = Application
-2 = Application instance
-3 = Interface or bearer
-4 = Network class
-5 = Platform policy class
-6..127 = Reserved for future GEISA-defined accounting scopes
-128..255 = Reserved for vendor-specific or operator-specific accounting scopes
-This resource defines the scope boundary for the counters, limits, quota state, throttle, block, or disabled state, and enforcement or evidence summaries represented by this accounting instance.
-]]></Description>
+1 = Application message traffic
+2 = Local application communication
+3 = Platform-mediated communication
+4..127 = Reserved for future GEISA-defined accounting scopes
+128..255 = Reserved for vendor-specific or operator-specific accounting scopes]]></Description>
       </Item>
-      <Item ID="12">
+      <Item ID="3">
         <Name>Scope Label</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -267,27 +151,186 @@ This resource defines the scope boundary for the counters, limits, quota state, 
 Optional human-readable or operator-assigned label describing the accounting scope when Accounting Scope is more specific than the application identified by resource 4050 AppID. Examples include an interface name, bearer label, network class, or operator policy bucket identifier.
 ]]></Description>
       </Item>
-      <Item ID="13">
-        <Name>Volume State</Name>
+      <Item ID="4">
+        <Name>Accounting Window Type</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Mandatory</Mandatory>
-        <Type>Integer</Type>
+        <Type>Unsigned Integer</Type>
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
+        <Description><![CDATA[Identifies the accounting window represented by this AppAccounting object instance.
+The primary AppAccounting instance for an application/application-instance/accounting scope SHOULD represent the current accounting period. Additional AppAccounting instances MAY exist for the same AppID, Accounting Class, and Accounting Scope to expose bounded secondary windows or views, such as a previous completed period, configured collection period, rolling window, lifetime view, or operator-defined view.
+Secondary instances MUST be distinguishable by this resource, Period Start Time, Period End Time, Scope Label where available, and AppID.
+0 = Current period or unspecified current window
+1 = Configured collection period
+2 = Current daily period
+3 = Previous completed daily period
+4 = Since reboot
+5 = Rolling window
+6 = Lifetime
+7 = Operator-defined
+8..127 = Reserved for future GEISA-defined accounting window types
+128..255 = Reserved for vendor-specific or operator-specific accounting window types]]></Description>
+      </Item>
+      <Item ID="5">
+        <Name>Collection Period</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>String</Type>
+        <RangeEnumeration/>
+        <Units/>
+        <Description><![CDATA[A string in RFC 5545 Recurrence Rule (RRule) format defining the configured recurring accounting period when the Accounting Window Type represents a configured or recurring period, e.g., "RRULE:FREQ=MINUTELY;INTERVAL=60".
+Period Start Time and Period End Time identify the actual accounting window represented by this object instance. Collection Period is optional because bounded windows may also be represented directly by start and end timestamps, or may represent non-recurring windows such as Since reboot, Lifetime, or a previous completed period.]]></Description>
+      </Item>
+      <Item ID="6">
+        <Name>Period Start Time</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Time</Type>
+        <RangeEnumeration/>
+        <Units/>
+        <Description><![CDATA[Start time for the accounting period or bounded window represented by the counters in this accounting instance.
+The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
+For non-recurring windows such as Since Reboot or Lifetime, this resource identifies the beginning of the accounting window.]]></Description>
+      </Item>
+      <Item ID="7">
+        <Name>Period End Time</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Time</Type>
+        <RangeEnumeration/>
+        <Units/>
+        <Description><![CDATA[End time for the accounting period or bounded window represented by the counters in this accounting instance.
+For the current period, this is the scheduled end or reset time for current-period counters and remaining quota values. For a previous completed period or other bounded historical view, this is the end time of that completed window.
+The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
+For open-ended windows such as Lifetime, this resource SHOULD identify the current evaluation boundary or MAY use 0 when no bounded end is defined by the implementation profile.]]></Description>
+      </Item>
+      <Item ID="8">
+        <Name>Last Update Timestamp</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Time</Type>
+        <RangeEnumeration/>
+        <Units/>
         <Description><![CDATA[
-Current quota or policy summary state for the accounting class and scope represented by this instance.
-0 = Unknown
-1 = Normal or available
-2 = Unlimited
-3 = Exhausted
-4 = Throttled
-5 = Blocked or policy restricted
-6..127 = Reserved for future GEISA-defined volume states
-128..255 = Reserved for vendor-specific or operator-specific volume states
+Time at which the platform last generated, refreshed, or updated the accounting snapshot used to populate this object instance.
+The value is encoded as LwM2M Time using Unix epoch seconds.
+
+The encoded value does not carry timezone metadata. Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
+This timestamp does not by itself prove that a new message, quota event, throttle transition, disabled transition, or policy violation occurred.
 ]]></Description>
       </Item>
+      <Item ID="10">
+        <Name>Total Bytes</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>bytes</Units>
+        <Description><![CDATA[
+Total number of bytes transmitted plus received so far during the current collection period for the accounting class and scope represented by this object instance.
+Total bytes are derived from TX Bytes plus RX Bytes for the modeled accounting scope.
+]]></Description>
+      </Item>
+      <Item ID="11">
+        <Name>TX Bytes</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>bytes</Units>
+        <Description><![CDATA[
+Number of bytes transmitted so far during the current collection period for the accounting class and scope represented by this object instance.
+TX bytes represent usage emitted by the application or accounting scope.
+]]></Description>
+      </Item>
+      <Item ID="12">
+        <Name>RX Bytes</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>bytes</Units>
+        <Description><![CDATA[
+Number of bytes received so far during the current collection period for the accounting class and scope represented by this object instance.
+RX bytes represent usage directed to the application or accounting scope when an authoritative inbound accounting source exists.
+]]></Description>
+      </Item>
+      <Item ID="13">
+        <Name>Total Messages</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>messages</Units>
+        <Description><![CDATA[Total number of app messages counted for the accounting class, scope, and window represented by this object instance.
+For app-message accounting scopes, this resource is part of the minimum sane accounting surface and MUST be exposed. The value SHOULD equal TX Messages plus RX Messages where both are available and counted by the same accounting policy.]]></Description>
+      </Item>
       <Item ID="14">
+        <Name>TX Messages</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>messages</Units>
+        <Description><![CDATA[Number of transmitted app messages counted for the accounting class, scope, and window represented by this object instance.
+For app-message accounting scopes, this resource is part of the minimum sane accounting surface and MUST be exposed. A value of 0 is valid when no transmitted messages have occurred in the represented window.]]></Description>
+      </Item>
+      <Item ID="15">
+        <Name>RX Messages</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>messages</Units>
+        <Description><![CDATA[Number of received app messages counted for the accounting class, scope, and window represented by this object instance.
+For app-message accounting scopes, this resource is part of the minimum sane accounting surface and MUST be exposed. A value of 0 is valid when no received messages have occurred in the represented window or when no inbound app-message traffic has occurred.]]></Description>
+      </Item>
+      <Item ID="16">
+        <Name>TX Packets</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units/>
+        <Description><![CDATA[Number of transmitted network packets counted for the accounting class, scope, and window represented by this object instance.
+This resource is optional because packet-level truth may not be available for logical app-message accounting or platform-mediated communication. Implementations MUST NOT approximate packets from message counts.]]></Description>
+      </Item>
+      <Item ID="17">
+        <Name>RX Packets</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units/>
+        <Description><![CDATA[Number of received network packets counted for the accounting class, scope, and window represented by this object instance.
+This resource is optional because packet-level truth may not be available for logical app-message accounting or platform-mediated communication. Implementations MUST NOT approximate packets from message counts.]]></Description>
+      </Item>
+      <Item ID="20">
+        <Name>Maximum Bytes</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>bytes</Units>
+        <Description><![CDATA[Hard limit maximum number of bytes allowed per accounting period for the application or accounting scope represented by this object instance.
+If a byte quota is configured, enforced, or reported for this accounting scope, this resource MUST be exposed and updated truthfully. If no byte quota applies, this resource MAY be omitted.]]></Description>
+      </Item>
+      <Item ID="21">
         <Name>Bytes Remaining</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -295,12 +338,10 @@ Current quota or policy summary state for the accounting class and scope represe
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
         <Units>bytes</Units>
-        <Description><![CDATA[
-Bytes remaining in the active collection or quota period for the accounting class and scope represented by this object instance.
-A value of zero indicates that the configured byte allowance has been exhausted or no bytes remain under the current policy.
-]]></Description>
+        <Description><![CDATA[Number of bytes remaining in the current accounting period before the byte quota for this accounting instance is exhausted.
+If a byte quota is configured, enforced, or reported for this accounting scope, this resource MUST be exposed and updated truthfully. If no byte quota applies, this resource MAY be omitted.]]></Description>
       </Item>
-      <Item ID="15">
+      <Item ID="22">
         <Name>Message Limit</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -308,12 +349,10 @@ A value of zero indicates that the configured byte allowance has been exhausted 
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
         <Units>messages</Units>
-        <Description><![CDATA[
-Configured message count limit for the active collection or quota period. This limit applies to messages accounted by the class and scope policy represented by this object instance, such as app messaging, platform-mediated communication, direct communication, local platform API use, service-flow communication, or other ADM or operator-defined accounting categories.
-It does not imply that all LwM2M protocol exchanges are counted unless policy explicitly defines that behavior.
-]]></Description>
+        <Description><![CDATA[Maximum number of app messages allowed per accounting period for the application or accounting scope represented by this object instance.
+If a message quota is configured, enforced, or reported for this accounting scope, this resource MUST be exposed and updated truthfully. If no message quota applies, this resource MAY be omitted.]]></Description>
       </Item>
-      <Item ID="16">
+      <Item ID="23">
         <Name>Messages Remaining</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -321,51 +360,30 @@ It does not imply that all LwM2M protocol exchanges are counted unless policy ex
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
         <Units>messages</Units>
-        <Description><![CDATA[
-Messages remaining in the active collection or quota period for messages accounted by the class and scope policy represented by this object instance.
-
-This value may be unavailable when no authoritative quota, limit, or policy source exists.
-]]></Description>
+        <Description><![CDATA[Number of app messages remaining in the current accounting period before the message quota for this accounting instance is exhausted.
+If a message quota is configured, enforced, or reported for this accounting scope, this resource MUST be exposed and updated truthfully. If no message quota applies, this resource MAY be omitted.]]></Description>
       </Item>
-      <Item ID="17">
-        <Name>TX Messages</Name>
+      <Item ID="30">
+        <Name>Quota State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units>messages</Units>
-        <Description><![CDATA[
-Number of messages transmitted so far during the current collection period for messages accounted by the class and scope policy represented by this object instance. This can include app messaging, platform-mediated communication, direct communication, local platform API use, service-flow communication, or other ADM or operator-defined accounting categories.
-It does not imply that all LwM2M protocol exchanges are counted unless policy explicitly defines that behavior.
-]]></Description>
+        <Mandatory>Mandatory</Mandatory>
+        <Type>Integer</Type>
+        <RangeEnumeration>0..255</RangeEnumeration>
+        <Units/>
+        <Description><![CDATA[Summary state for quota or budget availability for the accounting class, scope, and window represented by this instance.
+This state summarizes whether quota remains available, is unlimited, has been exhausted, or is subject to policy restriction. It applies to byte quotas, message quotas, or other GEISA-defined accounting budgets represented by this instance.
+Quota State is distinct from Throttle State. Quota State describes accounting budget availability. Throttle State describes the active communication constraint or enforcement behavior, such as throttled, blocked, disabled, or not constrained.
+0 = Unknown
+1 = Available
+2 = Unlimited
+3 = Exhausted
+4 = Throttled
+5 = Blocked or policy restricted
+6..127 = Reserved for future GEISA-defined quota states
+128..255 = Reserved for vendor-specific or operator-specific quota states]]></Description>
       </Item>
-      <Item ID="18">
-        <Name>RX Messages</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units>messages</Units>
-        <Description><![CDATA[
-Number of messages received so far during the current collection period for messages accounted by the class and scope policy represented by this object instance.
-RX message counts require an authoritative inbound accounting source and may be unavailable rather than inferred.
-]]></Description>
-      </Item>
-      <Item ID="19">
-        <Name>Total Messages</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration/>
-        <Units>messages</Units>
-        <Description><![CDATA[
-Total number of messages transmitted plus received so far during the current collection period for messages accounted by the class and scope policy represented by this object instance.
-]]></Description>
-      </Item>
-      <Item ID="20">
+      <Item ID="31">
         <Name>Throttle State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -388,16 +406,16 @@ enforcement function is administratively or configurationally disabled.
 128..255 = Reserved for vendor-specific or operator-specific throttle states
 ]]></Description>
       </Item>
-      <Item ID="21">
+      <Item ID="32">
         <Name>Throttle Reason</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
+        <Mandatory>Mandatory</Mandatory>
         <Type>Integer</Type>
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
-        <Description><![CDATA[
-Summary reason code for the current throttled, blocked, disabled, or otherwise constrained state of this application accounting scope.
+        <Description><![CDATA[Summary reason code for the current throttled, blocked, disabled, or otherwise constrained state of this application accounting scope.
+This resource MUST be exposed together with Throttle State. When Throttle State indicates Not throttled or no active constraint is present, this resource MUST read as 0 (None).
 0 = None
 1 = Unknown
 2 = Byte quota exceeded
@@ -420,10 +438,9 @@ Summary reason code for the current throttled, blocked, disabled, or otherwise c
 19 = Application requested termination
 20 = Administrative disable
 21..127 = Reserved for future GEISA-defined throttle reasons
-128..255 = Reserved for vendor-specific or operator-specific throttle reasons
-]]></Description>
+128..255 = Reserved for vendor-specific or operator-specific throttle reasons]]></Description>
       </Item>
-      <Item ID="22">
+      <Item ID="33">
         <Name>Throttle Rate Limit</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -438,70 +455,19 @@ This value may be unavailable when no policy-backed throttle source exists.
 Disabled state is represented by Throttle State and Throttle Reason where applicable.
 ]]></Description>
       </Item>
-      <Item ID="23">
-        <Name>Period Start Time</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Time</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Start time for the active collection period represented by the counters in this accounting instance.
-The value is encoded as LwM2M Time using Unix epoch time inseconds. The encoded value does not carry timezone metadata. Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, withfallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
-For non-recurring windows such as Since reboot or Lifetime, this resource identifies the beginning of the accounting window.
-]]></Description>
-      </Item>
-      <Item ID="24">
-        <Name>Next Reset Time</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Time</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Time at which current-period counters and remaining quota values are expected to reset for this accounting instance.
-The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata.
-Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
-For non-recurring windows such as Since reboot or Lifetime, this resource may be unavailable.
-]]></Description>
-      </Item>
-      <Item ID="25">
-        <Name>Last Update Timestamp</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Time</Type>
-        <RangeEnumeration/>
-        <Units/>
-        <Description><![CDATA[
-Time at which the platform last generated, refreshed, or updated the
-accounting snapshot used to populate this object instance.
-The value is encoded as LwM2M Time using Unix epoch seconds.
-The encoded value does not carry timezone metadata.
-Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
-This timestamp does not by itself prove that a new message, quota event, throttle transition, disabled transition, or policy violation occurred.
-]]></Description>
-      </Item>
-      <Item ID="26">
+      <Item ID="40">
         <Name>Last Throttle Timestamp</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
+        <Mandatory>Mandatory</Mandatory>
         <Type>Time</Type>
         <RangeEnumeration/>
         <Units/>
-        <Description><![CDATA[
-Selected evidence summary resource for operations monitoring.
-This value records the last known time the scope entered a throttled, blocked, disabled,
-or otherwise constrained state, when such evidence is available.
-It may be unavailable when no authoritative policy, quota, throttle, or enforcement evidence source exists.
-The value is encoded as LwM2M Time using Unix epoch seconds.
-The encoded value does not carry timezone metadata. Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
-]]></Description>
+        <Description><![CDATA[Last time this accounting instance entered a throttled, blocked, disabled, or otherwise constrained state.
+The value is encoded as LwM2M Time using Unix epoch seconds. A value of 0 indicates that no throttle, block, disabled, or constrained transition has been recorded for this accounting instance.
+This resource is summary evidence only. Detailed durable history SHOULD be recorded through the Event Log object, EMS/ADM records, or other platform-defined retention mechanisms.]]></Description>
       </Item>
-      <Item ID="27">
+      <Item ID="41">
         <Name>Last Quota Exhausted Timestamp</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -509,14 +475,10 @@ The encoded value does not carry timezone metadata. Device-local accounting peri
         <Type>Time</Type>
         <RangeEnumeration/>
         <Units/>
-        <Description><![CDATA[
-Selected evidence summary resource for operations monitoring. This value records the last known time a quota or limit was exhausted for this scope.
-It may be unavailable when no authoritative quota, limit, or policy source exists.
-The value is encoded as LwM2M Time using Unix epoch seconds.
-The encoded value does not carry timezone metadata. Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
-]]></Description>
+        <Description><![CDATA[Last time a quota was exhausted for this accounting instance.
+If quota exhaustion occurs or is enforced for this accounting scope, this resource MUST be exposed and updated truthfully. This resource is summary evidence only; detailed durable history SHOULD be recorded through the Event Log object, EMS/ADM records, or other platform-defined retention mechanisms.]]></Description>
       </Item>
-      <Item ID="28">
+      <Item ID="42">
         <Name>Last Policy Violation Timestamp</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -524,14 +486,10 @@ The encoded value does not carry timezone metadata. Device-local accounting peri
         <Type>Time</Type>
         <RangeEnumeration/>
         <Units/>
-        <Description><![CDATA[
-Selected evidence summary resource for operations monitoring. This value records the last known time an accounting, communication, security, QoS, or enforcement policy violation associated with this scope was recorded.
-It may be unavailable when no authoritative policy or enforcement evidence source exists.
-The value is encoded as LwM2M Time using Unix epoch seconds.
-The encoded value does not carry timezone metadata. Device-local accounting period boundaries are interpreted using /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS accounting policy applies.
-]]></Description>
+        <Description><![CDATA[Last time a policy violation was detected for this accounting instance.
+If policy violations are detected or reported for this accounting scope, this resource MUST be exposed and updated truthfully. This resource is summary evidence only; detailed durable history SHOULD be recorded through the Event Log object, EMS/ADM records, or other platform-defined retention mechanisms.]]></Description>
       </Item>
-      <Item ID="29">
+      <Item ID="43">
         <Name>Violation Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -539,13 +497,10 @@ The encoded value does not carry timezone metadata. Device-local accounting peri
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
         <Units>events</Units>
-        <Description><![CDATA[
-Selected evidence summary resource for operations monitoring.
-This value records the count of accounting, communication, security, QoS, or enforcement policy violations associated with this scope during the active accounting period.
-It may be unavailable when no authoritative policy or enforcement evidence source exists.
-]]></Description>
+        <Description><![CDATA[Number of policy violations detected for this accounting instance during the represented accounting period.
+If policy violations are detected or reported for this accounting scope, this resource MUST be exposed and updated truthfully. This resource is summary evidence only; detailed durable history SHOULD be recorded through the Event Log object, EMS/ADM records, or other platform-defined retention mechanisms.]]></Description>
       </Item>
-      <Item ID="30">
+      <Item ID="50">
         <Name>Reset Accounting Period</Name>
         <Operations>E</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -558,7 +513,33 @@ Reset current-period counters for the accounting class and scope represented by 
 Platforms may deny this operation or leave it unsupported according to operator policy, authorization, implementation profile, or lack of an accounting or enforcement path.
 ]]></Description>
       </Item>
-      <Item ID="31">
+      <Item ID="51">
+        <Name>Start Throttling</Name>
+        <Operations>E</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type/>
+        <RangeEnumeration/>
+        <Units/>
+        <Description><![CDATA[
+Apply constrained or rate-limited behavior for the application or accounting scope represented by this object instance.
+Platforms may deny this operation or leave it unsupported according to operator policy, authorization, implementation profile, or lack of an enforcement path.
+]]></Description>
+      </Item>
+      <Item ID="52">
+        <Name>Stop Throttling</Name>
+        <Operations>E</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type/>
+        <RangeEnumeration/>
+        <Units/>
+        <Description><![CDATA[
+Remove explicit throttling for the application or accounting scope represented by this object instance.
+Platforms may deny this operation or leave it unsupported according to operator policy, authorization, implementation profile, or lack of an enforcement path.
+]]></Description>
+      </Item>
+      <Item ID="53">
         <Name>Block Communication</Name>
         <Operations>E</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -572,7 +553,7 @@ This operation remains distinct from Start Throttling and applies only to the co
 Platforms may deny this operation or leave it unsupported according to operator policy, authorization, implementation profile, or lack of an accounting or enforcement path.
 ]]></Description>
       </Item>
-      <Item ID="32">
+      <Item ID="54">
         <Name>Unblock Communication</Name>
         <Operations>E</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -583,29 +564,8 @@ Platforms may deny this operation or leave it unsupported according to operator 
         <Description><![CDATA[
 Remove an explicit communication block for the communication covered by this accounting instance and scope.
 This operation remains distinct from Stop Throttling and applies only to the communication represented by this accounting instance unless the accounting scope explicitly covers a broader boundary.
+
 Platforms may deny this operation or leave it unsupported according to operator policy, authorization, implementation profile, or lack of an accounting or enforcement path.
-]]></Description>
-      </Item>
-      <Item ID="33">
-        <Name>Accounting Window Type</Name>
-        <Operations>R</Operations>
-        <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
-        <Type>Unsigned Integer</Type>
-        <RangeEnumeration>0..255</RangeEnumeration>
-        <Units/>
-        <Description><![CDATA[
-Identifies the accounting window represented by this AppAccounting object instance.
-Multiple AppAccounting instances may exist for the same AppID, Accounting Class, and Accounting Scope to expose different accounting windows such as configured collection period, daily, since-reboot, rolling-window, lifetime, or operator-defined accounting.
-0 = Unspecified
-1 = Configured collection period
-2 = Daily
-3 = Since reboot
-4 = Rolling window
-5 = Lifetime
-6 = Operator-defined
-7..127 = Reserved for future GEISA-defined accounting window types
-128..255 = Reserved for vendor-specific or operator-specific accounting window types
 ]]></Description>
       </Item>
       <Item ID="4050">
@@ -616,11 +576,8 @@ Multiple AppAccounting instances may exist for the same AppID, Accounting Class,
         <Type>Unsigned Integer</Type>
         <RangeEnumeration>2 bytes</RangeEnumeration>
         <Units/>
-        <Description><![CDATA[
-A local-scope numeric identifier for distinguishing applications within a specific platform or deployment environment.
-This value is not globally unique by itself. Upstream or fleet-level uniqueness requires endpoint or platform identity together with this AppID.
-Application-instance context is required where multiple local instances are possible.
-]]></Description>
+        <Description><![CDATA[The local GEISA AppID associated with this application accounting instance.
+This shared GEISA resource remains Resource ID 4050 by agreement and OMA resource allocation convention. It is used to correlate this accounting instance with application messaging, event/log records, software management, monitoring, and other GEISA app-scoped objects.]]></Description>
       </Item>
     </Resources>
     <Description2><![CDATA[


### PR DESCRIPTION
## Summary

Reworks the proposed GEISA `/3602` AppAccounting LwM2M object into a cleaner pre-OMA structure.

This keeps the same AppAccounting intent, but reorganizes the resource model around the operational meaning of the object.

## What changed

* Reordered GEISA-local resource IDs into reserved functional blocks:

  * `0..9` scope and accounting window
  * `10..19` usage counters
  * `20..29` limits and remaining budget
  * `30..39` quota and enforcement state
  * `40..49` selected evidence
  * `50..59` operator or EMS/ADM actions
* Shared GEISA AppID remains resource 4050
* Renamed `Volume State` to `Quota State` to better reflect byte, message, and future accounting budgets.
* Replaced the prior reset-oriented period wording with `Period End Time`, which works for both current and completed accounting windows.
* Clarified that the primary AppAccounting instance for an app/app-instance/accounting scope should represent the current accounting period.
* Clarified that secondary instances may expose bounded views such as previous completed period, configured period, rolling window, lifetime, or operator-defined windows.
* Clarified that 3602 is not intended to expose unbounded accounting history.
* Added/updated conditional MUST language for quotas and evidence.

## Design intent

The goal is to make /3602 easier for vendors, operators, and OMA reviewers to interpret:

* First identify the app, accounting scope, and window, followed by the observed usage
* Then expose configured limits and remaining budget
* Then expose quota/enforcement state
* Then expose selected evidence and actions

This avoids the object reading like “original byte accounting plus appended additions,” and makes the current app/accounting period row explicit.

## Notes

* `AppID` remains resource `4050` by agreement and OMA resource allocation convention.
* Packet counters remain optional because packet-level truth may not exist for logical app-message accounting.
* Quota limits remain optional at the XML level, but descriptions require them when quotas are configured, enforced, or reported.
* `/3602` reset remains separate from app configuration or messaging control.
* Previous-period/yesterday accounting may be exposed through a secondary `/3602` instance or through EMS/ADM/API/event-log/history mechanisms; it is not embedded into the current-period row.