### PR TITLE
api:actuators: add missing QoS and message type details

### DIFF
--- a/source/api/actuators.rst
+++ b/source/api/actuators.rst
@@ -84,6 +84,8 @@ status after a request when confirmation of state is required or desired.
 MQTT Details
 ------------
 
+QoS: 1 / Acknowledged R/R
+
 Get:
 
 - request: ``geisa/api/actuator/get/req/<userid>``


### PR DESCRIPTION
As the other API message specifications, the actuators API should also include the QoS and message type details.