### PR TITLE
cleanup of OMA object 3606 pre-OMA PR amendment.

### DIFF
--- a/source/adm/oma/3606.xml
+++ b/source/adm/oma/3606.xml
@@ -26,7 +26,8 @@ See TBD
 
 LEGAL DISCLAIMER
 
-Copyright 2019-2026 Open Mobile Alliance.
+Copyright 2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -65,7 +66,9 @@ https://www.omaspecworks.org/about/intellectual-property-rights/
     <Description1><![CDATA[
 This LwM2M Object configures GEISA Platform behavior for local monitoring, reporting, logging, queueing, and app-message handling.
 
-This Object is single-instance per edge device. It represents desired and effective behavior of the GEISA Platform for one edge device and is intended for operator or EMS-visible configuration state rather than current operational health.
+Resource identifiers are intentionally grouped with gaps between logical sections to allow future GEISA-defined resources to be added near related configuration state, sampling, monitoring-window, reporting, logging, queueing, app-message, retention, and app-accounting resources without renumbering existing resources. Requested configuration resources use even-numbered resource identifiers and their corresponding Effective resources use the immediately following odd-numbered resource identifiers. Undefined resource identifiers in those gaps are not implemented resources.
+
+This Object is single-instance per edge device. It represents requested and effective behavior of the GEISA Platform for one edge device and is intended for operator or EMS-visible configuration state rather than current operational health.
 
 This Object does not replace native LwM2M configuration for firmware, application lifecycle, cellular, APN, WLAN, bearer selection, remote SIM, or QoS. It does not carry app-domain configuration payloads; app-domain configuration uses the GEISA App Messaging Object. It does not report current platform health; the GEISA Platform Monitoring Object reports current platform health, state, and counters. It does not store durable logs or event records; those remain in the Event Log Object.
 ]]></Description1>
@@ -97,12 +100,12 @@ Platform-generated revision identifier for the current GEISA Platform configurat
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Current relationship between the desired GEISA Platform configuration and the effective configuration currently exposed by the platform.
+Current relationship between the requested GEISA Platform configuration and the effective configuration currently exposed by the platform.
 0 = Unknown
-1 = Effective configuration matches desired configuration
+1 = Effective configuration matches requested configuration
 2 = Pending application
 3 = Partially applied
-4 = Desired value adjusted by platform policy
+4 = Requested value adjusted by platform policy
 5 = Rejected
 6 = Reverted to previous effective configuration
 7..127 = Reserved for future GEISA-defined states
@@ -110,7 +113,7 @@ Current relationship between the desired GEISA Platform configuration and the ef
 ]]></Description>
       </Item>
       <Item ID="2">
-        <Name>Last Desired Configuration Update Time</Name>
+        <Name>Last Requested Configuration Update Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -118,7 +121,7 @@ Current relationship between the desired GEISA Platform configuration and the ef
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Time at which the desired GEISA Platform configuration was most recently requested, received, or revised. This timestamp reflects the desired configuration input, not necessarily the time at which the configuration became effective. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. When the timestamp is presented or interpreted in platform-local operational context, use /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
+Time at which the requested GEISA Platform configuration was most recently requested, received, or revised. This timestamp reflects the requested configuration input, not necessarily the time at which the configuration became effective. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. When the timestamp is presented or interpreted in platform-local operational context, use /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
       <Item ID="3">
@@ -142,7 +145,7 @@ The last time at which the effective GEISA Platform configuration was updated. T
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Time at which a desired GEISA Platform configuration was most recently rejected. This timestamp reflects the rejection decision time, not the time at which the desired configuration was originally requested. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. When the timestamp is presented or interpreted in platform-local operational context, use /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
+Time at which a requested GEISA Platform configuration was most recently rejected. This timestamp reflects the rejection decision time, not the time at which the requested configuration was originally requested. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. When the timestamp is presented or interpreted in platform-local operational context, use /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
       <Item ID="5">
@@ -182,8 +185,8 @@ Reason for the most recent configuration rejection.
 Short platform-generated detail associated with the most recent configuration rejection.
 ]]></Description>
       </Item>
-      <Item ID="10">
-        <Name>Desired Default Sampling Period</Name>
+      <Item ID="20">
+        <Name>Requested Default Sampling Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -191,12 +194,12 @@ Short platform-generated detail associated with the most recent configuration re
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired platform-side sampling or update cadence in seconds used when a more specific GEISA Platform cadence is not configured.
+Requested platform-side sampling or update cadence in seconds used when a more specific GEISA Platform cadence is not configured.
 
 This value controls how often the platform collects, refreshes, computes, or reports this class of operational data. It does not require the monitored OMA object to carry its own interval.
 ]]></Description>
       </Item>
-      <Item ID="11">
+      <Item ID="21">
         <Name>Effective Default Sampling Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -210,8 +213,8 @@ Effective platform-side sampling or update cadence in seconds currently used whe
 This value controls how often the platform collects, refreshes, computes, or reports this class of operational data. It does not require the monitored OMA object to carry its own interval.
 ]]></Description>
       </Item>
-      <Item ID="12">
-        <Name>Desired Host Sampling Period</Name>
+      <Item ID="22">
+        <Name>Requested Host Sampling Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -219,10 +222,10 @@ This value controls how often the platform collects, refreshes, computes, or rep
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired platform-side sampling or update cadence in seconds for host or device resource monitoring associated with GEISA platform behavior.
+Requested platform-side sampling or update cadence in seconds for host or device resource monitoring associated with GEISA platform behavior.
 ]]></Description>
       </Item>
-      <Item ID="13">
+      <Item ID="23">
         <Name>Effective Host Sampling Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -234,8 +237,8 @@ Desired platform-side sampling or update cadence in seconds for host or device r
 Effective platform-side sampling or update cadence in seconds currently used for host or device resource monitoring associated with GEISA platform behavior.
 ]]></Description>
       </Item>
-      <Item ID="14">
-        <Name>Desired Platform Sampling Period</Name>
+      <Item ID="24">
+        <Name>Requested Platform Sampling Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -243,10 +246,10 @@ Effective platform-side sampling or update cadence in seconds currently used for
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired platform-side sampling or update cadence in seconds for GEISA Platform monitoring and internal platform state collection.
+Requested platform-side sampling or update cadence in seconds for GEISA Platform monitoring and internal platform state collection.
 ]]></Description>
       </Item>
-      <Item ID="15">
+      <Item ID="25">
         <Name>Effective Platform Sampling Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -258,8 +261,8 @@ Desired platform-side sampling or update cadence in seconds for GEISA Platform m
 Effective platform-side sampling or update cadence in seconds currently used for GEISA Platform monitoring and internal platform state collection.
 ]]></Description>
       </Item>
-      <Item ID="16">
-        <Name>Desired App Monitoring Sampling Period</Name>
+      <Item ID="26">
+        <Name>Requested App Monitoring Sampling Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -267,10 +270,10 @@ Effective platform-side sampling or update cadence in seconds currently used for
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired platform-side sampling or update cadence in seconds for GEISA App Monitoring data collection.
+Requested platform-side sampling or update cadence in seconds for GEISA App Monitoring data collection.
 ]]></Description>
       </Item>
-      <Item ID="17">
+      <Item ID="27">
         <Name>Effective App Monitoring Sampling Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -282,8 +285,8 @@ Desired platform-side sampling or update cadence in seconds for GEISA App Monito
 Effective platform-side sampling or update cadence in seconds currently used for GEISA App Monitoring data collection.
 ]]></Description>
       </Item>
-      <Item ID="18">
-        <Name>Desired App Accounting Sampling Period</Name>
+      <Item ID="28">
+        <Name>Requested App Accounting Sampling Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -291,12 +294,12 @@ Effective platform-side sampling or update cadence in seconds currently used for
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired platform-side sampling or update cadence in seconds for GEISA App Accounting data collection and refresh.
+Requested platform-side sampling or update cadence in seconds for GEISA App Accounting data collection and refresh.
 
-This cadence controls how often accounting state is collected, recomputed, or reported. It is distinct from the app accounting collection period represented by resources 90 and 91 in this object.
+This cadence controls how often accounting state is collected, recomputed, or reported. It is distinct from the app accounting collection period represented by resources 200 and 201 in this object.
 ]]></Description>
       </Item>
-      <Item ID="19">
+      <Item ID="29">
         <Name>Effective App Accounting Sampling Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -307,11 +310,11 @@ This cadence controls how often accounting state is collected, recomputed, or re
         <Description><![CDATA[
 Effective platform-side sampling or update cadence in seconds currently used for GEISA App Accounting data collection and refresh.
 
-This cadence controls how often accounting state is collected, recomputed, or reported. It is distinct from the app accounting collection period represented by resources 90 and 91 in this object.
+This cadence controls how often accounting state is collected, recomputed, or reported. It is distinct from the app accounting collection period represented by resources 200 and 201 in this object.
 ]]></Description>
       </Item>
-      <Item ID="20">
-        <Name>Desired Default Monitoring Window</Name>
+      <Item ID="40">
+        <Name>Requested Default Monitoring Window</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -319,12 +322,12 @@ This cadence controls how often accounting state is collected, recomputed, or re
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired aggregation or evaluation window in seconds used when a more specific GEISA Platform monitoring window is not configured.
+Requested aggregation or evaluation window in seconds used when a more specific GEISA Platform monitoring window is not configured.
 
 This window controls over what duration samples are evaluated for derived values, alerting, health, or upstream update decisions.
 ]]></Description>
       </Item>
-      <Item ID="21">
+      <Item ID="41">
         <Name>Effective Default Monitoring Window</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -338,8 +341,8 @@ Effective aggregation or evaluation window in seconds currently used when a more
 This window controls over what duration samples are evaluated for derived values, alerting, health, or upstream update decisions.
 ]]></Description>
       </Item>
-      <Item ID="22">
-        <Name>Desired Host Monitoring Window</Name>
+      <Item ID="42">
+        <Name>Requested Host Monitoring Window</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -347,10 +350,10 @@ This window controls over what duration samples are evaluated for derived values
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired aggregation or evaluation window in seconds for host or device resource monitoring associated with GEISA platform behavior.
+Requested aggregation or evaluation window in seconds for host or device resource monitoring associated with GEISA platform behavior.
 ]]></Description>
       </Item>
-      <Item ID="23">
+      <Item ID="43">
         <Name>Effective Host Monitoring Window</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -362,8 +365,8 @@ Desired aggregation or evaluation window in seconds for host or device resource 
 Effective aggregation or evaluation window in seconds currently used for host or device resource monitoring associated with GEISA platform behavior.
 ]]></Description>
       </Item>
-      <Item ID="24">
-        <Name>Desired Platform Monitoring Window</Name>
+      <Item ID="44">
+        <Name>Requested Platform Monitoring Window</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -371,10 +374,10 @@ Effective aggregation or evaluation window in seconds currently used for host or
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired aggregation or evaluation window in seconds for GEISA Platform monitoring and derived platform state evaluation.
+Requested aggregation or evaluation window in seconds for GEISA Platform monitoring and derived platform state evaluation.
 ]]></Description>
       </Item>
-      <Item ID="25">
+      <Item ID="45">
         <Name>Effective Platform Monitoring Window</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -386,8 +389,8 @@ Desired aggregation or evaluation window in seconds for GEISA Platform monitorin
 Effective aggregation or evaluation window in seconds currently used for GEISA Platform monitoring and derived platform state evaluation.
 ]]></Description>
       </Item>
-      <Item ID="26">
-        <Name>Desired App Monitoring Window</Name>
+      <Item ID="46">
+        <Name>Requested App Monitoring Window</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -395,10 +398,10 @@ Effective aggregation or evaluation window in seconds currently used for GEISA P
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired aggregation or evaluation window in seconds for GEISA App Monitoring aggregation and derived state evaluation.
+Requested aggregation or evaluation window in seconds for GEISA App Monitoring aggregation and derived state evaluation.
 ]]></Description>
       </Item>
-      <Item ID="27">
+      <Item ID="47">
         <Name>Effective App Monitoring Window</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -410,8 +413,8 @@ Desired aggregation or evaluation window in seconds for GEISA App Monitoring agg
 Effective aggregation or evaluation window in seconds currently used for GEISA App Monitoring aggregation and derived state evaluation.
 ]]></Description>
       </Item>
-      <Item ID="30">
-        <Name>Desired Minimum Upstream Severity</Name>
+      <Item ID="60">
+        <Name>Requested Minimum Upstream Severity</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -419,7 +422,7 @@ Effective aggregation or evaluation window in seconds currently used for GEISA A
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired minimum severity threshold for upstream reporting.
+Requested minimum severity threshold for upstream reporting.
 
 0 = Unknown
 1 = Informational
@@ -431,7 +434,7 @@ Desired minimum severity threshold for upstream reporting.
 128..255 = Reserved for vendor-specific or operator-specific severities
 ]]></Description>
       </Item>
-      <Item ID="31">
+      <Item ID="61">
         <Name>Effective Minimum Upstream Severity</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -452,8 +455,8 @@ Effective minimum severity threshold currently used for upstream reporting.
 128..255 = Reserved for vendor-specific or operator-specific severities
 ]]></Description>
       </Item>
-      <Item ID="32">
-        <Name>Desired Event Suppression Period</Name>
+      <Item ID="62">
+        <Name>Requested Event Suppression Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -461,10 +464,10 @@ Effective minimum severity threshold currently used for upstream reporting.
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired suppression period in seconds used to limit repeated reporting of equivalent events or alarms.
+Requested suppression period in seconds used to limit repeated reporting of equivalent events or alarms.
 ]]></Description>
       </Item>
-      <Item ID="33">
+      <Item ID="63">
         <Name>Effective Event Suppression Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -476,8 +479,8 @@ Desired suppression period in seconds used to limit repeated reporting of equiva
 Effective suppression period in seconds currently used to limit repeated reporting of equivalent events or alarms.
 ]]></Description>
       </Item>
-      <Item ID="34">
-        <Name>Desired Clear/Recovery Reporting Enabled</Name>
+      <Item ID="64">
+        <Name>Requested Clear/Recovery Reporting Enabled</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -485,10 +488,10 @@ Effective suppression period in seconds currently used to limit repeated reporti
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired setting indicating whether clear or recovery events should be reported upstream when a previously reported condition returns to normal.
+Requested setting indicating whether clear or recovery events should be reported upstream when a previously reported condition returns to normal.
 ]]></Description>
       </Item>
-      <Item ID="35">
+      <Item ID="65">
         <Name>Effective Clear/Recovery Reporting Enabled</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -500,8 +503,8 @@ Desired setting indicating whether clear or recovery events should be reported u
 Effective setting currently used to determine whether clear or recovery events are reported upstream when a previously reported condition returns to normal.
 ]]></Description>
       </Item>
-      <Item ID="36">
-        <Name>Desired Clear Condition Duration</Name>
+      <Item ID="66">
+        <Name>Requested Clear Condition Duration</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -509,10 +512,10 @@ Effective setting currently used to determine whether clear or recovery events a
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired duration in seconds that a condition should remain clear before the platform reports a clear or recovery event.
+Requested duration in seconds that a condition should remain clear before the platform reports a clear or recovery event.
 ]]></Description>
       </Item>
-      <Item ID="37">
+      <Item ID="67">
         <Name>Effective Clear Condition Duration</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -524,8 +527,8 @@ Desired duration in seconds that a condition should remain clear before the plat
 Effective duration in seconds currently used before the platform reports a clear or recovery event.
 ]]></Description>
       </Item>
-      <Item ID="38">
-        <Name>Desired Default Reporting Priority</Name>
+      <Item ID="68">
+        <Name>Requested Default Reporting Priority</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -533,7 +536,7 @@ Effective duration in seconds currently used before the platform reports a clear
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired default reporting priority used when a more specific message or event priority is not supplied.
+Requested default reporting priority used when a more specific message or event priority is not supplied.
 
 0 = Unknown
 1 = Urgent
@@ -544,7 +547,7 @@ Desired default reporting priority used when a more specific message or event pr
 128..255 = Reserved for vendor-specific or operator-specific priorities
 ]]></Description>
       </Item>
-      <Item ID="39">
+      <Item ID="69">
         <Name>Effective Default Reporting Priority</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -564,8 +567,8 @@ Effective default reporting priority currently used when a more specific message
 128..255 = Reserved for vendor-specific or operator-specific priorities
 ]]></Description>
       </Item>
-      <Item ID="40">
-        <Name>Desired Platform Log Level</Name>
+      <Item ID="80">
+        <Name>Requested Platform Log Level</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -573,7 +576,7 @@ Effective default reporting priority currently used when a more specific message
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired log level for GEISA Platform services and components.
+Requested log level for GEISA Platform services and components.
 
 0 = Unknown
 1 = Off
@@ -586,7 +589,7 @@ Desired log level for GEISA Platform services and components.
 128..255 = Reserved for vendor-specific or operator-specific log levels
 ]]></Description>
       </Item>
-      <Item ID="41">
+      <Item ID="81">
         <Name>Effective Platform Log Level</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -608,8 +611,8 @@ Effective log level currently used for GEISA Platform services and components.
 128..255 = Reserved for vendor-specific or operator-specific log levels
 ]]></Description>
       </Item>
-      <Item ID="42">
-        <Name>Desired App Log Level Default</Name>
+      <Item ID="82">
+        <Name>Requested App Log Level Default</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -617,7 +620,7 @@ Effective log level currently used for GEISA Platform services and components.
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired default log level applied to GEISA applications when a more specific application log configuration is not provided.
+Requested default log level applied to GEISA applications when a more specific application log configuration is not provided.
 
 0 = Unknown
 1 = Off
@@ -630,7 +633,7 @@ Desired default log level applied to GEISA applications when a more specific app
 128..255 = Reserved for vendor-specific or operator-specific log levels
 ]]></Description>
       </Item>
-      <Item ID="43">
+      <Item ID="83">
         <Name>Effective App Log Level Default</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -652,32 +655,32 @@ Effective default log level currently applied to GEISA applications when a more 
 128..255 = Reserved for vendor-specific or operator-specific log levels
 ]]></Description>
       </Item>
-      <Item ID="44">
-        <Name>Desired Event Log Retention Count</Name>
+      <Item ID="84">
+        <Name>Requested Event Log Retention Count</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>entries</Units>
+        <Units>B</Units>
         <Description><![CDATA[
-Desired maximum retained event or log record count for GEISA-managed durable event storage. A value of 0 indicates that no count limit is configured or that retention is unlimited according to platform policy.
+Requested maximum retained event or log record count for GEISA-managed durable event storage. A value of 0 indicates that no count limit is configured or that retention is unlimited according to platform policy.
 ]]></Description>
       </Item>
-      <Item ID="45">
+      <Item ID="85">
         <Name>Effective Event Log Retention Count</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>entries</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Effective maximum retained event or log record count currently used for GEISA-managed durable event storage. A value of 0 indicates that no count limit is configured or that retention is unlimited according to platform policy.
 ]]></Description>
       </Item>
-      <Item ID="46">
-        <Name>Desired Audit Logging Enabled</Name>
+      <Item ID="86">
+        <Name>Requested Audit Logging Enabled</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -685,10 +688,10 @@ Effective maximum retained event or log record count currently used for GEISA-ma
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired setting indicating whether audit logging is enabled for GEISA Platform administrative or security-relevant actions.
+Requested setting indicating whether audit logging is enabled for GEISA Platform administrative or security-relevant actions.
 ]]></Description>
       </Item>
-      <Item ID="47">
+      <Item ID="87">
         <Name>Effective Audit Logging Enabled</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -700,8 +703,8 @@ Desired setting indicating whether audit logging is enabled for GEISA Platform a
 Effective setting currently used to determine whether audit logging is enabled for GEISA Platform administrative or security-relevant actions.
 ]]></Description>
       </Item>
-      <Item ID="48">
-        <Name>Desired Remote Logging Enabled</Name>
+      <Item ID="88">
+        <Name>Requested Remote Logging Enabled</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -709,10 +712,10 @@ Effective setting currently used to determine whether audit logging is enabled f
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired flag indicating whether platform-side remote logging is enabled.
+Requested flag indicating whether platform-side remote logging is enabled.
 ]]></Description>
       </Item>
-      <Item ID="49">
+      <Item ID="89">
         <Name>Effective Remote Logging Enabled</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -724,8 +727,8 @@ Desired flag indicating whether platform-side remote logging is enabled.
 Effective flag indicating whether platform-side remote logging is enabled.
 ]]></Description>
       </Item>
-      <Item ID="50">
-        <Name>Desired Remote Log Server</Name>
+      <Item ID="90">
+        <Name>Requested Remote Log Server</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -733,10 +736,10 @@ Effective flag indicating whether platform-side remote logging is enabled.
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired URI of the remote log collector or event sink used by platform remote logging.
+Requested URI of the remote log collector or event sink used by platform remote logging.
 ]]></Description>
       </Item>
-      <Item ID="51">
+      <Item ID="91">
         <Name>Effective Remote Log Server</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -748,8 +751,8 @@ Desired URI of the remote log collector or event sink used by platform remote lo
 Effective URI of the remote log collector or event sink used by platform remote logging.
 ]]></Description>
       </Item>
-      <Item ID="52">
-        <Name>Desired Remote Log Severity Threshold</Name>
+      <Item ID="92">
+        <Name>Requested Remote Log Severity Threshold</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -757,7 +760,7 @@ Effective URI of the remote log collector or event sink used by platform remote 
         <RangeEnumeration>0..7</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired minimum severity threshold for remote logging.
+Requested minimum severity threshold for remote logging.
 
 0 = Emergency
 1 = Alert
@@ -769,7 +772,7 @@ Desired minimum severity threshold for remote logging.
 7 = Debug
 ]]></Description>
       </Item>
-      <Item ID="53">
+      <Item ID="93">
         <Name>Effective Remote Log Severity Threshold</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -790,8 +793,8 @@ Effective minimum severity threshold for remote logging.
 7 = Debug
 ]]></Description>
       </Item>
-      <Item ID="54">
-        <Name>Desired Remote Log Policy Reference</Name>
+      <Item ID="94">
+        <Name>Requested Remote Log Policy Reference</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -799,10 +802,10 @@ Effective minimum severity threshold for remote logging.
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired reference or identifier for the remote logging policy currently associated with the platform.
+Requested reference or identifier for the remote logging policy currently associated with the platform.
 ]]></Description>
       </Item>
-      <Item ID="55">
+      <Item ID="95">
         <Name>Effective Remote Log Policy Reference</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -814,8 +817,8 @@ Desired reference or identifier for the remote logging policy currently associat
 Effective reference or identifier for the remote logging policy currently associated with the platform.
 ]]></Description>
       </Item>
-      <Item ID="56">
-        <Name>Desired Remote Log Transport Security Profile</Name>
+      <Item ID="96">
+        <Name>Requested Remote Log Transport Security Profile</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -823,10 +826,10 @@ Effective reference or identifier for the remote logging policy currently associ
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired transport security profile used for platform remote logging.
+Requested transport security profile used for platform remote logging.
 ]]></Description>
       </Item>
-      <Item ID="57">
+      <Item ID="97">
         <Name>Effective Remote Log Transport Security Profile</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -838,8 +841,8 @@ Desired transport security profile used for platform remote logging.
 Effective transport security profile used for platform remote logging.
 ]]></Description>
       </Item>
-      <Item ID="60">
-        <Name>Desired Upstream Queue Enabled</Name>
+      <Item ID="110">
+        <Name>Requested Upstream Queue Enabled</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -847,10 +850,10 @@ Effective transport security profile used for platform remote logging.
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired setting indicating whether the GEISA Platform should buffer outbound upstream messages in a queue or spool when immediate transmission is not possible or not preferred.
+Requested setting indicating whether the GEISA Platform should buffer outbound upstream messages in a queue or spool when immediate transmission is not possible or not preferred.
 ]]></Description>
       </Item>
-      <Item ID="61">
+      <Item ID="111">
         <Name>Effective Upstream Queue Enabled</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -862,56 +865,56 @@ Desired setting indicating whether the GEISA Platform should buffer outbound ups
 Effective setting currently used to determine whether the GEISA Platform buffers outbound upstream messages in a queue or spool.
 ]]></Description>
       </Item>
-      <Item ID="62">
-        <Name>Desired Max Queued Messages</Name>
+      <Item ID="112">
+        <Name>Requested Max Queued Messages</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
-Desired maximum number of messages that the upstream queue or spool should retain.
+Requested maximum number of messages that the upstream queue or spool should retain.
 ]]></Description>
       </Item>
-      <Item ID="63">
+      <Item ID="113">
         <Name>Effective Max Queued Messages</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Effective maximum number of messages currently retained by the upstream queue or spool.
 ]]></Description>
       </Item>
-      <Item ID="64">
-        <Name>Desired Max Queued Bytes</Name>
+      <Item ID="114">
+        <Name>Requested Max Queued Bytes</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>bytes</Units>
+        <Units>B</Units>
         <Description><![CDATA[
-Desired maximum queued or spooled payload volume in bytes for upstream buffering.
+Requested maximum queued or spooled payload volume in bytes for upstream buffering.
 ]]></Description>
       </Item>
-      <Item ID="65">
+      <Item ID="115">
         <Name>Effective Max Queued Bytes</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>bytes</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Effective maximum queued or spooled payload volume in bytes currently used for upstream buffering.
 ]]></Description>
       </Item>
-      <Item ID="66">
-        <Name>Desired Queue TTL</Name>
+      <Item ID="116">
+        <Name>Requested Queue TTL</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -919,10 +922,10 @@ Effective maximum queued or spooled payload volume in bytes currently used for u
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired time-to-live in seconds for queued or spooled messages before expiration. This value applies to messages retained in the platform queue or spool and may be derived from, or constrained by, the platform default message TTL when a more specific queue policy is not configured.
+Requested time-to-live in seconds for queued or spooled messages before expiration. This value applies to messages retained in the platform queue or spool and may be derived from, or constrained by, the platform default message TTL when a more specific queue policy is not configured.
 ]]></Description>
       </Item>
-      <Item ID="67">
+      <Item ID="117">
         <Name>Effective Queue TTL</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -934,8 +937,8 @@ Desired time-to-live in seconds for queued or spooled messages before expiration
 Effective time-to-live in seconds currently used for queued or spooled messages before expiration. This value reflects the platform-accepted queue or spool TTL after validation, policy limits, fallback handling, or default message TTL constraints have been applied.
 ]]></Description>
       </Item>
-      <Item ID="68">
-        <Name>Desired Queue Drop Policy</Name>
+      <Item ID="118">
+        <Name>Requested Queue Drop Policy</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -943,7 +946,7 @@ Effective time-to-live in seconds currently used for queued or spooled messages 
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired queue or spool drop policy used when buffering limits are reached.
+Requested queue or spool drop policy used when buffering limits are reached.
 
 0 = Unknown
 1 = Reject new messages
@@ -955,7 +958,7 @@ Desired queue or spool drop policy used when buffering limits are reached.
 128..255 = Reserved for vendor-specific or operator-specific drop policies
 ]]></Description>
       </Item>
-      <Item ID="69">
+      <Item ID="119">
         <Name>Effective Queue Drop Policy</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -976,8 +979,8 @@ Effective queue or spool drop policy currently used when buffering limits are re
 128..255 = Reserved for vendor-specific or operator-specific drop policies
 ]]></Description>
       </Item>
-      <Item ID="70">
-        <Name>Desired Queue Coalescing Enabled</Name>
+      <Item ID="120">
+        <Name>Requested Queue Coalescing Enabled</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -985,10 +988,10 @@ Effective queue or spool drop policy currently used when buffering limits are re
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired setting indicating whether the GEISA Platform may collapse eligible queued upstream messages before transmission or storage. When enabled, the platform can reduce redundant or stale queued updates according to the configured queue coalescing policy, such as keeping the latest state update while preserving events or alarms that must be delivered individually.
+Requested setting indicating whether the GEISA Platform may collapse eligible queued upstream messages before transmission or storage. When enabled, the platform can reduce redundant or stale queued updates according to the configured queue coalescing policy, such as keeping the latest state update while preserving events or alarms that must be delivered individually.
 ]]></Description>
       </Item>
-      <Item ID="71">
+      <Item ID="121">
         <Name>Effective Queue Coalescing Enabled</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1000,8 +1003,8 @@ Desired setting indicating whether the GEISA Platform may collapse eligible queu
 Effective setting indicating whether the GEISA Platform is currently allowed to collapse eligible queued upstream messages before transmission or storage. This value reflects the platform-accepted behavior after validation, policy limits, or fallback handling have been applied.
 ]]></Description>
       </Item>
-      <Item ID="72">
-        <Name>Desired Queue Coalescing Policy</Name>
+      <Item ID="122">
+        <Name>Requested Queue Coalescing Policy</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1009,7 +1012,7 @@ Effective setting indicating whether the GEISA Platform is currently allowed to 
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired policy for how the GEISA Platform should collapse eligible queued upstream messages when queue coalescing is enabled. The policy determines which queued messages may be combined, replaced, summarized, or preserved.
+Requested policy for how the GEISA Platform should collapse eligible queued upstream messages when queue coalescing is enabled. The policy determines which queued messages may be combined, replaced, summarized, or preserved.
 
 0 = Unknown
 1 = Disabled
@@ -1021,7 +1024,7 @@ Desired policy for how the GEISA Platform should collapse eligible queued upstre
 coalescing policies
 ]]></Description>
       </Item>
-      <Item ID="73">
+      <Item ID="123">
         <Name>Effective Queue Coalescing Policy</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1042,8 +1045,8 @@ Effective policy used by the GEISA Platform to collapse eligible queued upstream
 coalescing policies
 ]]></Description>
       </Item>
-      <Item ID="74">
-        <Name>Desired Default Message TTL</Name>
+      <Item ID="140">
+        <Name>Requested Default Message TTL</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1051,10 +1054,10 @@ coalescing policies
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired default time-to-live in seconds for messages buffered or handled by the GEISA Platform when a more specific TTL is not provided.
+Requested default time-to-live in seconds for messages buffered or handled by the GEISA Platform when a more specific TTL is not provided.
 ]]></Description>
       </Item>
-      <Item ID="75">
+      <Item ID="141">
         <Name>Effective Default Message TTL</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1066,32 +1069,32 @@ Desired default time-to-live in seconds for messages buffered or handled by the 
 Effective default time-to-live in seconds currently used for messages buffered or handled by the GEISA Platform when a more specific TTL is not provided.
 ]]></Description>
       </Item>
-      <Item ID="76">
-        <Name>Desired Max App Message Payload Size</Name>
+      <Item ID="142">
+        <Name>Requested Max App Message Payload Size</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>bytes</Units>
+        <Units>B</Units>
         <Description><![CDATA[
-Desired maximum GEISA application message payload size in bytes accepted by the platform before local rejection, truncation, or alternate handling according to platform policy.
+Requested maximum GEISA application message payload size in bytes accepted by the platform before local rejection, truncation, or alternate handling according to platform policy.
 ]]></Description>
       </Item>
-      <Item ID="77">
+      <Item ID="143">
         <Name>Effective Max App Message Payload Size</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>bytes</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Effective maximum GEISA application message payload size in bytes currently accepted by the platform before local rejection, truncation, or alternate handling according to platform policy.
 ]]></Description>
       </Item>
-      <Item ID="78">
-        <Name>Desired App Message Priority Policy Reference</Name>
+      <Item ID="144">
+        <Name>Requested App Message Priority Policy Reference</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1099,10 +1102,10 @@ Effective maximum GEISA application message payload size in bytes currently acce
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired platform-defined policy reference currently used to map, adjust, or constrain GEISA application message priorities before local handling or upstream reporting. The reference may identify a local policy name, policy version, URI, or other operator-defined policy identifier.
+Requested platform-defined policy reference currently used to map, adjust, or constrain GEISA application message priorities before local handling or upstream reporting. The reference may identify a local policy name, policy version, URI, or other operator-defined policy identifier.
 ]]></Description>
       </Item>
-      <Item ID="79">
+      <Item ID="145">
         <Name>Effective App Message Priority Policy Reference</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1114,8 +1117,8 @@ Desired platform-defined policy reference currently used to map, adjust, or cons
 Effective platform-defined policy reference currently used to map, adjust, or constrain GEISA application message priorities before local handling or upstream reporting. The reference may identify a local policy name, policy version, URI, or other operator-defined policy identifier.
 ]]></Description>
       </Item>
-      <Item ID="80">
-        <Name>Desired App Message Routing Policy Reference</Name>
+      <Item ID="146">
+        <Name>Requested App Message Routing Policy Reference</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1123,10 +1126,10 @@ Effective platform-defined policy reference currently used to map, adjust, or co
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired platform-defined policy reference used to select how GEISA application messages are routed, constrained, or handled before local processing or upstream reporting. The reference may identify a local policy name, policy version, URI, or other operator-defined policy identifier.
+Requested platform-defined policy reference used to select how GEISA application messages are routed, constrained, or handled before local processing or upstream reporting. The reference may identify a local policy name, policy version, URI, or other operator-defined policy identifier.
 ]]></Description>
       </Item>
-      <Item ID="81">
+      <Item ID="147">
         <Name>Effective App Message Routing Policy Reference</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1138,8 +1141,8 @@ Desired platform-defined policy reference used to select how GEISA application m
 Effective platform-defined policy reference currently used to route, constrain, or handle GEISA application messages before local processing or upstream reporting. The reference may identify a local policy name, policy version, URI, or other operator-defined policy identifier.
 ]]></Description>
       </Item>
-      <Item ID="82">
-        <Name>Desired QoS Policy Reference</Name>
+      <Item ID="148">
+        <Name>Requested QoS Policy Reference</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1147,10 +1150,10 @@ Effective platform-defined policy reference currently used to route, constrain, 
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired reference or identifier for the QoS policy associated with GEISA Platform behavior. Detailed bearer or flow QoS configuration remains in Object 10540 and related network or bearer objects.
+Requested reference or identifier for the QoS policy associated with GEISA Platform behavior. Detailed bearer or flow QoS configuration remains in Object 10540 and related network or bearer objects.
 ]]></Description>
       </Item>
-      <Item ID="83">
+      <Item ID="149">
         <Name>Effective QoS Policy Reference</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1162,8 +1165,8 @@ Desired reference or identifier for the QoS policy associated with GEISA Platfor
 Effective reference or identifier for the QoS policy currently associated with GEISA Platform behavior. Detailed bearer or flow QoS configuration remains in Object 10540 and related network or bearer objects.
 ]]></Description>
       </Item>
-      <Item ID="90">
-        <Name>Desired App Accounting Collection Period</Name>
+      <Item ID="160">
+        <Name>Requested Outbound Message State Retention Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1171,10 +1174,226 @@ Effective reference or identifier for the QoS policy currently associated with G
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired accounting collection period in seconds used to represent the app accounting counter window for the platform.
+Requested maximum retention age in seconds for eligible completed outbound app-message state after the message is no longer active in the outbound queue. The platform may remove eligible records when any applicable age, count, or byte limit is reached, but active or still-referenced records are not required to be removed. This limit is distinct from queue TTL.
 ]]></Description>
       </Item>
-      <Item ID="91">
+      <Item ID="161">
+        <Name>Effective Outbound Message State Retention Period</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>s</Units>
+        <Description><![CDATA[
+Effective maximum retention age in seconds currently used for eligible completed outbound app-message state after the message is no longer active in the outbound queue. The platform may remove eligible records when any applicable age, count, or byte limit is reached, but active or still-referenced records are not required to be removed. This limit is distinct from queue TTL.
+]]></Description>
+      </Item>
+      <Item ID="162">
+        <Name>Requested Outbound Message State Retention Count</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Requested maximum retained count of eligible completed outbound app-message state records. The platform may remove eligible records when any applicable age, count, or byte limit is reached, but active or still-referenced records are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="163">
+        <Name>Effective Outbound Message State Retention Count</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Effective maximum retained count currently used for eligible completed outbound app-message state records. The platform may remove eligible records when any applicable age, count, or byte limit is reached, but active or still-referenced records are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="164">
+        <Name>Requested Outbound Queue Recovery Snapshot Retention Count</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Requested maximum retained count of eligible local outbound queue recovery snapshots. The platform may remove eligible artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="165">
+        <Name>Effective Outbound Queue Recovery Snapshot Retention Count</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Effective maximum retained count currently used for eligible local outbound queue recovery snapshots. The platform may remove eligible artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="166">
+        <Name>Requested Outbound Queue Recovery Snapshot Retention Bytes</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Requested maximum retained bytes for eligible local outbound queue recovery snapshots. The platform may remove eligible artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="167">
+        <Name>Effective Outbound Queue Recovery Snapshot Retention Bytes</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Effective maximum retained bytes currently used for eligible local outbound queue recovery snapshots. The platform may remove eligible artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="180">
+        <Name>Requested Inbound Message Mailbox Retention Period</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>s</Units>
+        <Description><![CDATA[
+Requested maximum retention age in seconds for eligible inbound server-to-client mailbox records and mailbox-managed data after they are no longer active or otherwise required. The platform may remove eligible records or artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced records or artifacts are not required to be removed. This does not imply app delivery, consume, or acknowledgement semantics.
+]]></Description>
+      </Item>
+      <Item ID="181">
+        <Name>Effective Inbound Message Mailbox Retention Period</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>s</Units>
+        <Description><![CDATA[
+Effective maximum retention age in seconds currently used for eligible inbound server-to-client mailbox records and mailbox-managed data after they are no longer active or otherwise required. The platform may remove eligible records or artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced records or artifacts are not required to be removed. This does not imply app delivery, consume, or acknowledgement semantics.
+]]></Description>
+      </Item>
+      <Item ID="182">
+        <Name>Requested Inbound Message Mailbox Retention Count</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Requested maximum retained count of eligible inbound server-to-client mailbox records and mailbox-managed data. The platform may remove eligible records or artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced records or artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="183">
+        <Name>Effective Inbound Message Mailbox Retention Count</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Effective maximum retained count currently used for eligible inbound server-to-client mailbox records and mailbox-managed data. The platform may remove eligible records or artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced records or artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="184">
+        <Name>Requested Inbound Message Mailbox Retention Bytes</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Requested maximum retained bytes for eligible inbound server-to-client mailbox records and mailbox-managed data. The platform may remove eligible records or artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced records or artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="185">
+        <Name>Effective Inbound Message Mailbox Retention Bytes</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Effective maximum retained bytes currently used for eligible inbound server-to-client mailbox records and mailbox-managed data. The platform may remove eligible records or artifacts when any applicable age, count, or byte limit is reached, but active or still-referenced records or artifacts are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="186">
+        <Name>Requested Message Payload Retention Period</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>s</Units>
+        <Description><![CDATA[
+Requested maximum retention age in seconds for eligible locally retained app-message payload blobs after they are no longer required by active queue entries, mailbox records, retained message state, audit records, or other retained platform references. The platform may remove eligible payloads when any applicable age, count, or byte limit is reached, but active or still-referenced payloads are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="187">
+        <Name>Effective Message Payload Retention Period</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>s</Units>
+        <Description><![CDATA[
+Effective maximum retention age in seconds currently used for eligible locally retained app-message payload blobs after they are no longer required by active queue entries, mailbox records, retained message state, audit records, or other retained platform references. The platform may remove eligible payloads when any applicable age, count, or byte limit is reached, but active or still-referenced payloads are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="188">
+        <Name>Requested Message Payload Retention Bytes</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Requested maximum retained bytes for eligible locally retained app-message payload blobs after they are no longer required by active queue entries, mailbox records, retained message state, audit records, or other retained platform references. The platform may remove eligible payloads when any applicable age, count, or byte limit is reached, but active or still-referenced payloads are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="189">
+        <Name>Effective Message Payload Retention Bytes</Name>
+        <Operations>R</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>B</Units>
+        <Description><![CDATA[
+Effective maximum retained bytes currently used for eligible locally retained app-message payload blobs after they are no longer required by active queue entries, mailbox records, retained message state, audit records, or other retained platform references. The platform may remove eligible payloads when any applicable age, count, or byte limit is reached, but active or still-referenced payloads are not required to be removed.
+]]></Description>
+      </Item>
+      <Item ID="200">
+        <Name>Requested App Accounting Collection Period</Name>
+        <Operations>RW</Operations>
+        <MultipleInstances>Single</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Type>Unsigned Integer</Type>
+        <RangeEnumeration/>
+        <Units>s</Units>
+        <Description><![CDATA[
+Requested accounting collection period in seconds used to represent the app accounting counter window for the platform.
+]]></Description>
+      </Item>
+      <Item ID="201">
         <Name>Effective App Accounting Collection Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1186,8 +1405,8 @@ Desired accounting collection period in seconds used to represent the app accoun
 Effective accounting collection period in seconds currently used to represent the app accounting counter window for the platform.
 ]]></Description>
       </Item>
-      <Item ID="92">
-        <Name>Desired App Accounting Window Types</Name>
+      <Item ID="202">
+        <Name>Requested App Accounting Window Types</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1195,7 +1414,7 @@ Effective accounting collection period in seconds currently used to represent th
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired bitmask of supported app accounting window types.
+Requested bitmask of supported app accounting window types.
 
 0 = Unspecified / implementation default
 1 = Configured collection period
@@ -1207,7 +1426,7 @@ Desired bitmask of supported app accounting window types.
 Higher powers of two are reserved for future window types.
 ]]></Description>
       </Item>
-      <Item ID="93">
+      <Item ID="203">
         <Name>Effective App Accounting Window Types</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1228,8 +1447,8 @@ Effective bitmask of supported app accounting window types.
 Higher powers of two are reserved for future window type expansion.
 ]]></Description>
       </Item>
-      <Item ID="94">
-        <Name>Desired App Accounting Rolling Window Duration</Name>
+      <Item ID="204">
+        <Name>Requested App Accounting Rolling Window Duration</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1237,10 +1456,10 @@ Higher powers of two are reserved for future window type expansion.
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired rolling-window duration in seconds for app accounting.
+Requested rolling-window duration in seconds for app accounting.
 ]]></Description>
       </Item>
-      <Item ID="95">
+      <Item ID="205">
         <Name>Effective App Accounting Rolling Window Duration</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1252,8 +1471,8 @@ Desired rolling-window duration in seconds for app accounting.
 Effective rolling-window duration in seconds currently used for app accounting.
 ]]></Description>
       </Item>
-      <Item ID="96">
-        <Name>Desired App Accounting Retention Count</Name>
+      <Item ID="206">
+        <Name>Requested App Accounting Retention Count</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1261,10 +1480,10 @@ Effective rolling-window duration in seconds currently used for app accounting.
         <RangeEnumeration/>
         <Units>count</Units>
         <Description><![CDATA[
-Desired retained history count for app accounting window instances or snapshots.
+Requested retained history count for app accounting window instances or snapshots.
 ]]></Description>
       </Item>
-      <Item ID="97">
+      <Item ID="207">
         <Name>Effective App Accounting Retention Count</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1276,8 +1495,8 @@ Desired retained history count for app accounting window instances or snapshots.
 Effective retained history count for app accounting window instances or snapshots.
 ]]></Description>
       </Item>
-      <Item ID="98">
-        <Name>Desired App Accounting Policy Reference</Name>
+      <Item ID="208">
+        <Name>Requested App Accounting Policy Reference</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1285,10 +1504,10 @@ Effective retained history count for app accounting window instances or snapshot
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired reference or identifier for the app accounting policy currently associated with the platform.
+Requested reference or identifier for the app accounting policy currently associated with the platform.
 ]]></Description>
       </Item>
-      <Item ID="99">
+      <Item ID="209">
         <Name>Effective App Accounting Policy Reference</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1300,8 +1519,8 @@ Desired reference or identifier for the app accounting policy currently associat
 Effective reference or identifier for the app accounting policy currently associated with the platform.
 ]]></Description>
       </Item>
-      <Item ID="100">
-        <Name>Per-App Accounting Overrides Enabled</Name>
+      <Item ID="210">
+        <Name>Requested Per-App Accounting Overrides Enabled</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1309,10 +1528,10 @@ Effective reference or identifier for the app accounting policy currently associ
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired flag indicating whether per-app accounting policy overrides are permitted in future runtime behavior.
+Requested flag indicating whether per-app accounting policy overrides are permitted in future runtime behavior.
 ]]></Description>
       </Item>
-      <Item ID="101">
+      <Item ID="211">
         <Name>Effective Per-App Accounting Overrides Enabled</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1324,80 +1543,80 @@ Desired flag indicating whether per-app accounting policy overrides are permitte
 Effective flag indicating whether per-app accounting policy overrides are permitted in future runtime behavior.
 ]]></Description>
       </Item>
-      <Item ID="110">
-        <Name>Desired Default App Accounting Maximum Bytes</Name>
+      <Item ID="220">
+        <Name>Requested Default App Accounting Maximum Bytes</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>bytes</Units>
+        <Units>B</Units>
         <Description><![CDATA[
-Desired maximum bytes allowed during the accounting collection period. A value of zero means unlimited.
+Requested maximum bytes allowed during the accounting collection period. A value of zero means unlimited.
 ]]></Description>
       </Item>
-      <Item ID="111">
+      <Item ID="221">
         <Name>Effective Default App Accounting Maximum Bytes</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>bytes</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Effective maximum bytes currently allowed during the accounting collection period. A value of zero means unlimited.
 ]]></Description>
       </Item>
-      <Item ID="112">
-        <Name>Desired Default App Accounting Message Limit</Name>
+      <Item ID="222">
+        <Name>Requested Default App Accounting Message Limit</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
-Desired maximum number of messages allowed during the accounting collection period. A value of zero means unlimited.
+Requested maximum number of messages allowed during the accounting collection period. A value of zero means unlimited.
 ]]></Description>
       </Item>
-      <Item ID="113">
+      <Item ID="223">
         <Name>Effective Default App Accounting Message Limit</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Effective maximum number of messages currently allowed during the accounting collection period. A value of zero means unlimited.
 ]]></Description>
       </Item>
-      <Item ID="114">
-        <Name>Desired Default App Accounting Throttle Message Limit</Name>
+      <Item ID="224">
+        <Name>Requested Default App Accounting Throttle Message Limit</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
-Desired message limit used by throttling policy during the throttle period. A value of zero means unlimited.
+Requested message limit used by throttling policy during the throttle period. A value of zero means unlimited.
 ]]></Description>
       </Item>
-      <Item ID="115">
+      <Item ID="225">
         <Name>Effective Default App Accounting Throttle Message Limit</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Effective message limit currently used by throttling policy during the throttle period. A value of zero means unlimited.
 ]]></Description>
       </Item>
-      <Item ID="116">
-        <Name>Desired Default App Accounting Throttle Period</Name>
+      <Item ID="226">
+        <Name>Requested Default App Accounting Throttle Period</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1405,10 +1624,10 @@ Effective message limit currently used by throttling policy during the throttle 
         <RangeEnumeration/>
         <Units>s</Units>
         <Description><![CDATA[
-Desired throttle period in seconds. A value of zero disables the throttle period.
+Requested throttle period in seconds. A value of zero disables the throttle period.
 ]]></Description>
       </Item>
-      <Item ID="117">
+      <Item ID="227">
         <Name>Effective Default App Accounting Throttle Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1420,8 +1639,8 @@ Desired throttle period in seconds. A value of zero disables the throttle period
 Effective throttle period in seconds. A value of zero disables the throttle period.
 ]]></Description>
       </Item>
-      <Item ID="118">
-        <Name>Desired Quota Exhaustion Action</Name>
+      <Item ID="228">
+        <Name>Requested Quota Exhaustion Action</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1429,7 +1648,7 @@ Effective throttle period in seconds. A value of zero disables the throttle peri
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Desired local platform action to take when an accounting quota or limit is exhausted. Upstream ADM/EMS may observe, alert, or enforce related behavior, but this value describes the local platform action only.
+Requested local platform action to take when an accounting quota or limit is exhausted. Upstream ADM/EMS may observe, alert, or enforce related behavior, but this value describes the local platform action only.
 
 0 = Unknown
 1 = No local enforcement
@@ -1443,7 +1662,7 @@ Desired local platform action to take when an accounting quota or limit is exhau
 128..255 = Reserved for vendor-specific or operator-specific actions
 ]]></Description>
       </Item>
-      <Item ID="119">
+      <Item ID="229">
         <Name>Effective Quota Exhaustion Action</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1466,8 +1685,8 @@ Effective local platform action currently taken when an accounting quota or limi
 128..255 = Reserved for vendor-specific or operator-specific actions
 ]]></Description>
       </Item>
-      <Item ID="120">
-        <Name>Desired Accounting Enforcement Policy Reference</Name>
+      <Item ID="230">
+        <Name>Requested Accounting Enforcement Policy Reference</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
@@ -1475,10 +1694,10 @@ Effective local platform action currently taken when an accounting quota or limi
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Desired reference or identifier for the accounting enforcement policy currently associated with the platform.
+Requested reference or identifier for the accounting enforcement policy currently associated with the platform.
 ]]></Description>
       </Item>
-      <Item ID="121">
+      <Item ID="231">
         <Name>Effective Accounting Enforcement Policy Reference</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -1490,7 +1709,6 @@ Desired reference or identifier for the accounting enforcement policy currently 
 Effective reference or identifier for the accounting enforcement policy currently associated with the platform.
 ]]></Description>
       </Item>
-
     </Resources>
     <Description2><![CDATA[
 


### PR DESCRIPTION
## Summary

This PR cleans up the proposed `/3606` PlatformConfiguration object after group discussion and review of the pending OMA-validated PR.  No material changes were made other than the resource grouping/gaps, copyright and minor wording cleanup; the same number of actual/used resources and resource IDs remains the same as presented while alowing for future saner expansion if/when needed.

Changes include:

- Restored the GEISA contributor copyright block.
- Replaced Desired terminology with Requested terminology for configuration inputs.
- Reordered and renumbered GEISA-defined resources into logical groups with future extension room.
- Preserved the Requested/Effective resource pairing convention:
  - Requested resources use even-numbered resource IDs.
  - Corresponding Effective resources use the immediately following odd-numbered resource IDs.
- Added an object-level note explaining intentional resource ID grouping, gaps, and the Requested/Effective even/odd convention.

## Resource ID grouping

Resource IDs are now grouped as follows:

- `0-6`: configuration revision / state / update / rejection metadata
- `20-29`: sampling periods
- `40-47`: monitoring windows
- `60-69`: upstream severity / reporting behavior
- `80-97`: logging behavior
- `110-123`: upstream queue behavior
- `140-149`: app-message TTL / payload / routing / QoS references
- `160-167`: outbound message state / recovery snapshot retention
- `180-189`: inbound mailbox / payload retention
- `200-211`: app-accounting collection / windows / policy
- `220-231`: app-accounting default limits / quota / enforcement

The gaps provide room for future GEISA-defined resources to be added near related sections without renumbering existing resources or being messy for human parsing/readability.