### PR TITLE
3605 pre-OMA-submission cleanup

### DIFF
--- a/source/adm/oma/3605.xml
+++ b/source/adm/oma/3605.xml
@@ -26,7 +26,8 @@ See TBD
 
 LEGAL DISCLAIMER
 
-Copyright 2019-2026 Open Mobile Alliance.
+Copyright 2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -65,7 +66,9 @@ https://www.omaspecworks.org/about/intellectual-property-rights/
     <Description1><![CDATA[
 This LwM2M Object provides platform-scoped monitoring state for GEISA-capable platform functions, components, services, queues, APIs, and operational paths.
 
-Each Object Instance represents the platform's monitoring view for one platform component or for an aggregate platform scope. Values may be produced from bounded read-time checks, recently cached local checks, platform status snapshots, or retained component telemetry. This Object is intended for EMA health, LwM2M client health, registration and bootstrap state, upstream reporting health, local API broker or service health, app message bridge health, local monitoring function health, event log service health, and upstream queue or spool health.  Platform Implementors may have their own components mapped into this instance via the use of the vendor-specific reservation IDs.
+Resource identifiers are intentionally grouped with gaps between logical sections to allow future GEISA-defined resources to be added near related component identity, component health, monitoring-window, LwM2M registration, upstream communication, queueing, API broker, platform-service health, and execute-action resources without renumbering existing resources. Undefined resource identifiers in those gaps are not implemented resources.
+
+Each Object Instance represents the platform's monitoring view for one platform component, service, function, operational path, or aggregate platform scope. Values may be produced from bounded read-time checks, recently cached local checks, platform status snapshots, or retained component telemetry. This Object is intended for EMA health, LwM2M client health, registration and bootstrap state, upstream reporting health, local API broker or service health, app message bridge health, local monitoring function health, event log service health, and upstream queue or spool health. Platform implementers may map their own components using the vendor-specific or operator-specific Component Type reservation range when an exact match is not already provided.
 
 This Object does not require continuous telemetry collection. It does not imply a daemon, service, process, or engine architecture. Optional resources may be unavailable when the platform does not implement, expose, or retain the corresponding function, counter, timestamp, or component state.
 ]]></Description1>
@@ -148,7 +151,6 @@ Version of the GEISA Platform component, when available from runtime metadata, s
         <Units/>
         <Description><![CDATA[
 Current health state for this GEISA Platform component.
-
 0 = Unknown
 1 = Healthy
 2 = Degraded
@@ -165,12 +167,12 @@ Current health state for this GEISA Platform component.
         <Name>Health Reason</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
+        <Mandatory>Mandatory</Mandatory>
         <Type>String</Type>
         <RangeEnumeration/>
         <Units/>
         <Description><![CDATA[
-Short platform-generated reason associated with the current Component Health State.
+Short platform-generated reason associated with the current Component Health State. When no specific reason is available, the platform may report an implementation-defined empty, none, or unknown reason.
 ]]></Description>
       </Item>
       <Item ID="6">
@@ -197,23 +199,23 @@ Time at which the Component Health State most recently changed. The value is enc
 Time at which the current or most recent execution of the component started, when available from the platform. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="8">
+      <Item ID="10">
         <Name>Restart Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Integer</Type>
         <RangeEnumeration/>
-        <Units>restarts</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Number of component restarts during the current monitoring period.
 ]]></Description>
       </Item>
-      <Item ID="9">
+      <Item ID="11">
         <Name>Monitoring Window</Name>
         <Operations>RW</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
+        <Mandatory>Mandatory</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
         <Units>s</Units>
@@ -221,11 +223,11 @@ Number of component restarts during the current monitoring period.
 Monitoring window in seconds used for current-period counters and derived health evaluation for this component.
 ]]></Description>
       </Item>
-      <Item ID="10">
+      <Item ID="12">
         <Name>Monitoring Period Start Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Optional</Mandatory>
+        <Mandatory>Mandatory</Mandatory>
         <Type>Time</Type>
         <RangeEnumeration/>
         <Units/>
@@ -233,7 +235,7 @@ Monitoring window in seconds used for current-period counters and derived health
 Start time for the active monitoring period used by current-period counters and derived health state. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="11">
+      <Item ID="13">
         <Name>Last Update Timestamp</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -245,7 +247,7 @@ Start time for the active monitoring period used by current-period counters and 
 Time at which the platform most recently refreshed, generated, or updated the monitoring snapshot represented by this object instance. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="12">
+      <Item ID="20">
         <Name>LwM2M Registration State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -255,7 +257,6 @@ Time at which the platform most recently refreshed, generated, or updated the mo
         <Units/>
         <Description><![CDATA[
 Current LwM2M registration state, when this Object Instance represents an EMA, LwM2M client, or aggregate GEISA Platform scope.
-
 0 = Unknown
 1 = Not registered
 2 = Registering
@@ -268,7 +269,7 @@ Current LwM2M registration state, when this Object Instance represents an EMA, L
 128..255 = Reserved for vendor-specific or operator-specific registration states
 ]]></Description>
       </Item>
-      <Item ID="13">
+      <Item ID="21">
         <Name>Last Registration Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -280,7 +281,7 @@ Current LwM2M registration state, when this Object Instance represents an EMA, L
 Time of the most recent successful LwM2M registration, when known. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="14">
+      <Item ID="22">
         <Name>Last Registration Update Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -292,7 +293,7 @@ Time of the most recent successful LwM2M registration, when known. The value is 
 Time of the most recent successful LwM2M registration update, when known. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="15">
+      <Item ID="23">
         <Name>Registration Lifetime</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -304,7 +305,7 @@ Time of the most recent successful LwM2M registration update, when known. The va
 Current LwM2M registration lifetime in seconds.
 ]]></Description>
       </Item>
-      <Item ID="16">
+      <Item ID="24">
         <Name>Bootstrap State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -314,7 +315,6 @@ Current LwM2M registration lifetime in seconds.
         <Units/>
         <Description><![CDATA[
 Current bootstrap state, when applicable.
-
 0 = Unknown
 1 = Not required
 2 = Required
@@ -325,7 +325,7 @@ Current bootstrap state, when applicable.
 128..255 = Reserved for vendor-specific or operator-specific bootstrap states
 ]]></Description>
       </Item>
-      <Item ID="17">
+      <Item ID="30">
         <Name>Upstream Communication State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -335,7 +335,6 @@ Current bootstrap state, when applicable.
         <Units/>
         <Description><![CDATA[
 Current upstream communication state for GEISA Platform reporting.
-
 0 = Unknown
 1 = Disabled
 2 = Enabled down
@@ -347,7 +346,7 @@ Current upstream communication state for GEISA Platform reporting.
 128..255 = Reserved for vendor-specific or operator-specific upstream communication states
 ]]></Description>
       </Item>
-      <Item ID="18">
+      <Item ID="31">
         <Name>Last Upstream Success Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -359,7 +358,7 @@ Current upstream communication state for GEISA Platform reporting.
 Timestamp of the most recent successful upstream send, handoff, delivery, or communication observed or retained by the platform for this component, function, or path, when available. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="19">
+      <Item ID="32">
         <Name>Last Upstream Error Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -371,67 +370,67 @@ Timestamp of the most recent successful upstream send, handoff, delivery, or com
 Timestamp of the most recent upstream send, handoff, delivery, or communication error observed or retained by the platform for this component, function, or path, when available. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="20">
+      <Item ID="33">
         <Name>Upstream Error Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>errors</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of upstream send, handoff, delivery, or communication errors observed or retained by the platform during the current monitoring period.
 ]]></Description>
       </Item>
-      <Item ID="21">
+      <Item ID="34">
         <Name>Active Observe Count</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>observations</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of active observe relationships for the monitored component, function, or path where such telemetry is available.
 ]]></Description>
       </Item>
-      <Item ID="22">
+      <Item ID="35">
         <Name>Failed Notify Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>notifications</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of failed Notify deliveries during the current monitoring period where such telemetry is available.
 ]]></Description>
       </Item>
-      <Item ID="23">
+      <Item ID="36">
         <Name>Suppressed Event Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>events</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of events suppressed by policy, throttling, coalescing, backpressure, or other platform behavior during the current monitoring period where such telemetry is available.
 ]]></Description>
       </Item>
-      <Item ID="24">
+      <Item ID="37">
         <Name>Dropped Event Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>events</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of events dropped due to queueing, transport, resource, policy, or delivery failure during the current monitoring period where such telemetry is available.
 ]]></Description>
       </Item>
-      <Item ID="25">
+      <Item ID="40">
         <Name>Queue Health State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -441,7 +440,6 @@ Count of events dropped due to queueing, transport, resource, policy, or deliver
         <Units/>
         <Description><![CDATA[
 Health state of the upstream queue or spool associated with this component.
-
 0 = Unknown
 1 = Healthy
 2 = Degraded
@@ -452,31 +450,31 @@ Health state of the upstream queue or spool associated with this component.
 128..255 = Reserved for vendor-specific or operator-specific queue health states
 ]]></Description>
       </Item>
-      <Item ID="26">
+      <Item ID="41">
         <Name>Pending Upstream Messages</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Number of pending upstream GEISA Platform messages currently queued or spooled for delivery.
 ]]></Description>
       </Item>
-      <Item ID="27">
+      <Item ID="42">
         <Name>Pending Upstream Bytes</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>bytes</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Total bytes currently queued or spooled for upstream GEISA Platform delivery.
 ]]></Description>
       </Item>
-      <Item ID="28">
+      <Item ID="43">
         <Name>Oldest Pending Message Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -488,31 +486,31 @@ Total bytes currently queued or spooled for upstream GEISA Platform delivery.
 Timestamp of the oldest pending upstream or platform message in the monitored queue or path when one exists. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="29">
+      <Item ID="44">
         <Name>Dropped Upstream Messages Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Number of upstream GEISA Platform messages dropped during the current monitoring period.
 ]]></Description>
       </Item>
-      <Item ID="30">
+      <Item ID="45">
         <Name>Expired Upstream Messages Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>messages</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Number of queued or spooled upstream GEISA Platform messages that expired before successful delivery during the current monitoring period.
 ]]></Description>
       </Item>
-      <Item ID="31">
+      <Item ID="50">
         <Name>API Broker Health State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -521,8 +519,7 @@ Number of queued or spooled upstream GEISA Platform messages that expired before
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Health state of the local GEISA API broker, when applicable.
-
+Health state of the local GEISA API broker or API broker function represented by this component or aggregate instance, when applicable.
 0 = Unknown
 1 = Healthy
 2 = Degraded
@@ -532,43 +529,43 @@ Health state of the local GEISA API broker, when applicable.
 128..255 = Reserved for vendor-specific or operator-specific API broker health states
 ]]></Description>
       </Item>
-      <Item ID="32">
+      <Item ID="51">
         <Name>API Request Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>requests</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of API requests observed or retained by the monitored API or function during the current monitoring period. Generic event-log activity does not by itself satisfy this resource unless it is also an API request counted by that monitored function.
 ]]></Description>
       </Item>
-      <Item ID="33">
+      <Item ID="52">
         <Name>API Error Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>errors</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of API errors observed or retained by the monitored API or function during the current monitoring period.
 ]]></Description>
       </Item>
-      <Item ID="34">
+      <Item ID="53">
         <Name>Unauthorized API Attempt Count Current Period</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
         <Mandatory>Optional</Mandatory>
         <Type>Unsigned Integer</Type>
         <RangeEnumeration/>
-        <Units>attempts</Units>
+        <Units>B</Units>
         <Description><![CDATA[
 Count of unauthorized API requests observed or retained by the monitored API or function during the current monitoring period.
 ]]></Description>
       </Item>
-      <Item ID="35">
+      <Item ID="60">
         <Name>App Message Bridge Health State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -577,8 +574,7 @@ Count of unauthorized API requests observed or retained by the monitored API or 
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Health state of the local app message bridge that connects GEISA API messaging to ADM/LwM2M upstream or downstream handling, when applicable.
-
+Health state of the local app message bridge function represented by this component or aggregate instance, when applicable.
 0 = Unknown
 1 = Healthy
 2 = Degraded
@@ -588,7 +584,7 @@ Health state of the local app message bridge that connects GEISA API messaging t
 128..255 = Reserved for vendor-specific or operator-specific bridge health states
 ]]></Description>
       </Item>
-      <Item ID="36">
+      <Item ID="61">
         <Name>Event Log Service Health State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -597,8 +593,7 @@ Health state of the local app message bridge that connects GEISA API messaging t
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Health state of the local event log service or durable event recording path, when applicable.
-
+Health state of the local event log service or durable event recording path represented by this component or aggregate instance, when applicable.
 0 = Unknown
 1 = Healthy
 2 = Degraded
@@ -608,7 +603,7 @@ Health state of the local event log service or durable event recording path, whe
 128..255 = Reserved for vendor-specific or operator-specific event log health states
 ]]></Description>
       </Item>
-      <Item ID="37">
+      <Item ID="62">
         <Name>Local Monitoring Function Health State</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -617,8 +612,7 @@ Health state of the local event log service or durable event recording path, whe
         <RangeEnumeration>0..255</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-Health state of the local monitoring function responsible for producing, refreshing, or exposing platform monitoring data when such a function is present. This allows embedded implementations, standalone implementations, disabled profiles, and profiles where no separate local monitoring function exists.
-
+Health state of the local monitoring function responsible for producing, refreshing, or exposing platform monitoring data represented by this component or aggregate instance, when such a function is present. This allows embedded implementations, standalone implementations, disabled profiles, and profiles where no separate local monitoring function exists.
 0 = Unknown
 1 = Healthy
 2 = Degraded
@@ -628,7 +622,7 @@ Health state of the local monitoring function responsible for producing, refresh
 128..255 = Reserved for vendor-specific or operator-specific monitoring function health states
 ]]></Description>
       </Item>
-      <Item ID="38">
+      <Item ID="63">
         <Name>Last Durable Event Time</Name>
         <Operations>R</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -640,7 +634,7 @@ Health state of the local monitoring function responsible for producing, refresh
 Time at which this component most recently wrote or caused a durable event or log record to be written. The value is encoded as LwM2M Time using Unix epoch seconds. The encoded value does not carry timezone metadata. Platform-local interpretation uses /3/0/15 Timezone, with fallback to /3/0/14 UTC Offset when Timezone is unavailable, unless a more specific ADM or EMS policy applies.
 ]]></Description>
       </Item>
-      <Item ID="39">
+      <Item ID="70">
         <Name>Request Status Refresh</Name>
         <Operations>E</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -652,7 +646,7 @@ Time at which this component most recently wrote or caused a durable event or lo
 Request that the platform refresh the current status of this platform component and update this Object Instance. Platforms may deny this operation or leave it unsupported according to operator policy, authorization, component type, connectivity state, device state, safety considerations, or implementation profile.
 ]]></Description>
       </Item>
-      <Item ID="40">
+      <Item ID="71">
         <Name>Reset Monitoring Counters</Name>
         <Operations>E</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -664,7 +658,7 @@ Request that the platform refresh the current status of this platform component 
 Reset current-period monitoring counters for this Object Instance and start a new monitoring period. Platforms may deny this operation or leave it unsupported according to operator policy, authorization, component type, connectivity state, device state, safety considerations, or implementation profile.
 ]]></Description>
       </Item>
-      <Item ID="41">
+      <Item ID="72">
         <Name>Flush Upstream Queue</Name>
         <Operations>E</Operations>
         <MultipleInstances>Single</MultipleInstances>
@@ -676,7 +670,7 @@ Reset current-period monitoring counters for this Object Instance and start a ne
 Request immediate delivery of queued or spooled upstream messages associated with this component. Platforms may deny this operation or leave it unsupported according to operator policy, authorization, component type, connectivity state, device state, safety considerations, or implementation profile.
 ]]></Description>
       </Item>
-      <Item ID="42">
+      <Item ID="73">
         <Name>Restart Component</Name>
         <Operations>E</Operations>
         <MultipleInstances>Single</MultipleInstances>


### PR DESCRIPTION
## Summary

This PR cleans up the proposed `/3605` PlatformMonitoring object after group discussion and review of the OMA pending PR for 0.9 release.  Note that aside from copyright, resource id ordering/grouping and gaps, no functional changes or additions were made vs the group review other than a few additions as Mandatory.

Changes include:

* Restored the GEISA contributor copyright block.
* Reordered and renumbered GEISA-defined resources into logical groups with future extension room.
* Added an object-level note explaining intentional resource ID grouping and gaps.
* Clarified that object instances may represent a component, service, function, operational path, or aggregate platform scope.
* Preserved the OMA registry-normalized unit/type changes from the OMA-validated object file.
* Updated selected mandatory fields needed for useful platform monitoring and operational interpretation.
* Clarified component/aggregate applicability for API broker, app-message bridge, event log service, and local monitoring health resources.
* Clarified that mandatory Health Reason may report an empty, none, unknown, or implementation-defined reason when no specific reason is available.

## Resource ID grouping

Resource IDs are now grouped as follows:

* `0-7`: component identity / component health / lifecycle timestamps
* `10-13`: restart / monitoring window / freshness
* `20-24`: LwM2M registration / bootstrap state
* `30-37`: upstream communication / observe / notify / event counts
* `40-45`: upstream queue / pending and dropped messages
* `50-53`: local API broker / API counters
* `60-63`: platform service health summaries
* `70-73`: execute actions

The gaps allow room for future GEISA-defined resources to be added near related sections without renumbering existing resources or having to tack onto the end.