### PR TITLE
OMA obj 3600 minor cleanup pre-OMA 0.9 submission, no material changes other than …

### DIFF
--- a/source/adm/oma/3600.xml
+++ b/source/adm/oma/3600.xml
@@ -144,16 +144,16 @@ priority values when competing messages are otherwise eligible for delivery.
         <Units/>
         <Description><![CDATA[
 Classifies the app-message payload carried by this app-scoped messaging instance. Applies to both Client Message (Resource 1) and Server Message (Resource 0). Not all types apply in both directions.
-0: UNSPECIFIED – Message type is not specified or not yet classified.
-1: CONFIG – App-facing desired or effective configuration state.
-2: COMMAND – Action request to perform work now or soon.
-3: COMMAND_RESULT – Result of a COMMAND execution, distinct from
+0: UNSPECIFIED - Message type is not specified or not yet classified.
+1: CONFIG - App-facing desired or effective configuration state.
+2: COMMAND - Action request to perform work now or soon.
+3: COMMAND_RESULT - Result of a COMMAND execution, distinct from
 transport-level response acceptance.
-4: STATUS – Current state, lifecycle, readiness, mode, or policy/quota state.
-5: EVENT – Operationally meaningful occurrence worth recording or routing.
-6: ALARM – Actionable, high-severity, security, safety, or policy condition requiring prompt attention or special handling.
-7: APP_DATA – Supplemental application-specific data that intentioally does not fit CONFIG, COMMAND, STATUS, EVENT, ALARM, COMMAND_RESULT, or TELEMETRY.
-8: TELEMETRY – Measurement-oriented numeric or structured observations, usually time-series, snapshot, interval, or resource metrics.
+4: STATUS - Current state, lifecycle, readiness, mode, or policy/quota state.
+5: EVENT - Operationally meaningful occurrence worth recording or routing.
+6: ALARM - Actionable, high-severity, security, safety, or policy condition requiring prompt attention or special handling.
+7: APP_DATA - Supplemental application-specific data that intentionally does not fit CONFIG, COMMAND, STATUS, EVENT, ALARM, COMMAND_RESULT, or TELEMETRY.
+8: TELEMETRY - Measurement-oriented numeric or structured observations, usually time-series, snapshot, interval, or resource metrics.
 9-100: Reserved for future GEISA use.
 101-254: Reserved for Proprietary use.
 ]]></Description>
@@ -191,7 +191,7 @@ Media type for the app-message payload encoding, such as application/json, appli
         <RangeEnumeration>2 bytes</RangeEnumeration>
         <Units/>
         <Description><![CDATA[
-A local-scope numeric application identity for distinguishing edge applications within a specific deployment environment. Resource 4050 AppID is not globally unique by itself. EMS or upstream correlation uses endpoint or platform identity together with resource 4050 AppID, and application instance identity where needed.
+A unique local-scope identifier for distinguishing edge applications within a specific deployment environment. EMS or upstream correlation uses endpoint or platform identity together with resource 4050 AppID, and application instance identity where needed.
 ]]></Description>
       </Item>
     </Resources>


### PR DESCRIPTION
## Summary

cleans up the proposed `/3600` AppMessaging object after review of the OMA-validated object snapshot.

Changes include:

* Restored the GEISA contributor copyright block.
* Converted DOS/CRLF line endings from the OMA tool-validated copy to Unix/LF line endings before committing.
* Kept the Leshan-compatible versioned object URN:

  * `urn:oma:lwm2m:ext:3600:1.1`
* Made `Message Priority` mandatory so app-scoped messages consistently expose delivery priority for ordering, scheduling, throttling, and QoS/policy mapping.
* Clarified priority ordering details:

  * Lower numeric values represent higher delivery priority.
  * Platforms should prefer lower numeric priority values before higher numeric values when competing messages are otherwise eligible for delivery.
* minor typo fixes