### PR TITLE
fixed ObjectURN to match ObjectVersion.

### DIFF
--- a/source/adm/oma/20.xml
+++ b/source/adm/oma/20.xml
@@ -63,7 +63,7 @@ The Event Log Object is a multiple Instances Object defined for logging data in 
 The Resources of that Object are based on the OMA LwM2M set of reusable Resources dedicated to logging event activity.
 ]]></Description1>
     <ObjectID>20</ObjectID>
-    <ObjectURN>urn:oma:lwm2m:oma:20:3.0</ObjectURN>
+    <ObjectURN>urn:oma:lwm2m:oma:20:3.2</ObjectURN>
     <LWM2MVersion>1.1</LWM2MVersion>
     <ObjectVersion>3.2</ObjectVersion>
     <MultipleInstances>Multiple</MultipleInstances>


### PR DESCRIPTION
Updated the Event Log ObjectURN suffix from 3.0 to 3.2 so it matches ObjectVersion 3.2.
Probably 'ok-ish' as it was, but will cause prbolems at least with Leshan, so - fixed.

No resource IDs, types, operations, or descriptions are changed.