### PR TITLE
Fix Pages workflow Python dependencies

### DIFF
--- a/.github/workflows/spec-publish-pages.yml
+++ b/.github/workflows/spec-publish-pages.yml
@@ -56,8 +56,13 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
+          python3 -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install \
+            GitPython \
+            sphinx \
+            sphinxcontrib-svg2pdfconverter
 
       - name: Install Mermaid CLI with sandbox wrapper
         run: |
@@ -107,6 +112,7 @@ jobs:
 
       - name: Build specification
         run: |
+          . venv/bin/activate
           xvfb-run -a make clean all
 
       - name: Stage specification site


### PR DESCRIPTION
## Summary

Fixes the specification Pages publishing workflow Python setup.

The workflow was trying to install from root `requirements.txt` but we don't have
one in the repo. This updates the Pages workflow to match the working manual build workflow by creating a venv and installing the required Python packages inline.

