### PR TITLE
auto-detect and use python venv if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,13 @@ SPHINXTARGETS ?= html latexpdf
 SOURCEDIR     = source
 BUILDDIR      = build
 
+# detect and use the python venv if present
+ifneq ("$(wildcard $(PWD)/venv/bin/python)", "")
+PYTHONVENV	= $(PWD)/venv/
+else
+PYTHONVENV	=
+endif
+
 # GEISA is supporting mermaid and drawio diagrams as part of the spec, but
 # these diagrams are treated as independent source files to be built.  RST
 # files should reference the image.
@@ -73,4 +80,4 @@ all: $(SPHINXTARGETS)
 	rsvg-convert -f=pdf -o $@ $<
 
 $(SPHINXTARGETS): Makefile prep
-	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	$(SHELL) -c "PATH=$(PYTHONVENV:/=/bin:)$$PATH $(SPHINXBUILD) -M $@ \"$(SOURCEDIR)\" \"$(BUILDDIR)\" $(SPHINXOPTS)"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ source venv/bin/activate
 
 (venv) $ pip3 install GitPython sphinx sphinxcontrib-svg2pdfconverter
 
-(venv) $ make all
+(venv) $ deactivate
+
+$ make -j4 all
 
 </pre>
 


### PR DESCRIPTION
dont require activation of venv for each build, have the build system do it