### PR TITLE
Pin OMA LwM2M registry branch for GEISA objects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "source/adm/external/lwm2m-registry"]
+	path = source/adm/external/lwm2m-registry
+	url = https://github.com/OpenMobileAlliance/lwm2m-registry.git
+	branch = GEISA-LwM2M-Objects

--- a/README.md
+++ b/README.md
@@ -13,15 +13,36 @@ Follow the onboarding link for details about participating in our community
 process. You are also welcome to fork this repository and submit pull requests
 if you have additions or corrections you would like considered.
 
-GEISA maintains its formal specification as a set of reStructured text files,
-which are converted to HTML via
-[Sphinx](https://www.sphinx-doc.org/en/master/index.html). See the
-[Sphinx documentation](https://www.sphinx-doc.org/en/master/index.html) for
-details on Sphinx.
+GEISA maintains its formal specification as a set of reStructuredText files
+that are built into HTML and PDF using
+[Sphinx](https://www.sphinx-doc.org/en/master/). See the
+[Sphinx documentation](https://www.sphinx-doc.org/en/master/) for details.
+
+GEISA also uses a Git submodule for relevant OMA objects from the
+[LwM2M Registry](https://github.com/OpenMobileAlliance/lwm2m-registry).
+Because this content is provided via a submodule, it is **not** populated by a
+plain `git clone` and the directory will appear empty until the submodule is
+initialized.
+
+For an initial clone of the GEISA specification repository, use:
+
+```bash
+git clone --recurse-submodules <repo-url>
+```
+
+If you have already cloned the repository, fetch the submodule from the
+repository root with:
+
+```bash
+git submodule update --init source/adm/external/lwm2m-registry
+```
+
+Refer to [`source/adm/external/README.md`](source/adm/external/README.md) for
+additional information on GEISA OMA objects.
 
 Python `venv` creates a virtual environment so that Sphinx can be installed
 using its own separate packages and not break anything in the existing
-environment. Depending on your environment, you may need to install python
+environment. Depending on your environment, you may need to install Python
 `venv` using your system package manager.
 
 The GEISA spec also supports generated diagrams. Mermaid is used for sequence

--- a/source/adm/external/README.md
+++ b/source/adm/external/README.md
@@ -1,0 +1,52 @@
+# External ADM / OMA references
+
+This directory contains external references used by the GEISA specification build
+and review process.
+
+## `lwm2m-registry`
+
+Pinned git submodule for the OMA LightweightM2M registry branch used for GEISA
+LwM2M Object review and alignment.
+
+- Upstream: `https://github.com/OpenMobileAlliance/lwm2m-registry`
+- Branch: `GEISA-LwM2M-Objects`
+
+The submodule is intentionally pinned by commit. Update the submodule pointer
+when the agreed OMA registry branch advances.
+
+Note as this content is provided via a git submodule, it is not populated by a
+plain `git clone` and will appear empty.
+
+To fetch it after cloning the geisa specification repo:
+  <from repo root>
+  git submodule update --init source/adm/external/lwm2m-registry
+
+### GEISA-relevant OMA LwM2M objects
+
+The pinned OMA LwM2M registry submodule contains the full OMA registry. The
+following objects are the GEISA-relevant object set currently referenced for
+GEISA ADM review, implementation alignment, and OMA submission tracking.
+
+- **20 — Event Log** (`lwm2m-registry/20.xml`): Shared event, alarm, and
+  operational log model used by GEISA devices and applications.  This is
+  the standard / prior /20 Object with minor additions for GEISA and
+  generic usage.
+- **3600 — GEISA Application Messaging** (`lwm2m-registry/3600.xml`):
+  Application message transport and delivery state model.
+- **3601 — GEISA Host Monitoring** (`lwm2m-registry/3601.xml`): Host/platform
+  resource and health monitoring for GEISA-capable devices.
+- **3602 — GEISA Application Accounting** (`lwm2m-registry/3602.xml`):
+  Per-application accounting, quota, and policy-state reporting.
+- **3604 — GEISA Application Communication Accounting**
+  (`lwm2m-registry/3604.xml`): Communication accounting and traffic counters for
+  GEISA applications.
+- **3605 — GEISA Platform Monitoring** (`lwm2m-registry/3605.xml`):
+  Platform-level monitoring and operational state.
+- **3606 — GEISA Platform Configuration** (`lwm2m-registry/3606.xml`): Platform
+  configuration and policy exposure for GEISA-capable devices.
+
+Supporting standard OMA objects such as `/3` Device, `/4` Connectivity
+Monitoring, `/5` Firmware Update, `/6` Location, `/7` Connectivity Statistics,
+and `/9` Software Management remain part of the broader LwM2M baseline. The
+list above identifies the GEISA-specific or GEISA-extended object set that
+should be checked first when updating this submodule pin.


### PR DESCRIPTION
## Summary
- adds the OMA LwM2M registry as a pinned submodule under `source/adm/external/lwm2m-registry` 
- the submodule to the current GEISA object review branch 
- added external/README.md to document the GEISA-relevant OMA object set and intended usage in 

## Why
- keeps the OMA object review/submission source explicit and reproducible
- makes the external GEISA-relevant LwM2M object set easy to locate during specification review and alignment
- avoids mixing this external reference material into unrelated specification content

## Notes
- the submodule tracks the OMA registry repository and records the current pinned commit from branch `GEISA-LwM2M-Objects`
- the submodule remains commit-pinned; the branch entry in `.gitmodules` is informational for future updates
