### PR TITLE
Updated LwM2M requirements & references

### DIFF
--- a/source/adm/lwm2m.rst
+++ b/source/adm/lwm2m.rst
@@ -18,7 +18,10 @@ GEISA Application & Device Management uses the Open Mobile Alliance Lightweight 
   v1.1.
 * ADM conformant platforms and EMS SHALL support CoAP over UDP for
   message transport. [LWM2M-Transport]_
-* ADM conformant platforms and EMS SHALL support DTLS for CoAp security.
+* ADM conformant platforms and EMS SHALL support DTLS for CoAP security.
+* ADM conformant platforms and EMS SHALL support Certificate mode with EST as
+  per [LWM2M-Transport]_ 5.2.4.
+* ADM conformant platforms and EMS SHALL support EST over CoAP per [RFC9148]_
 * ADM conformant platforms and EMS SHALL support the Bootstrap, Registration,
   Device Management and Information Reporting interfaces.
 * ADM conformant platforms and EMS SHALL support the Mandatory resources of
@@ -43,6 +46,9 @@ GEISA Application & Device Management uses the Open Mobile Alliance Lightweight 
   * ID 3601 -- GEISA Host Monitoring
   * ID 3602 -- GEISA App Accounting
   * ID 3603 -- GEISA Wi-SUN Radio Management
+  * ID 3604 -- GEISA App Monitoring
+  * ID 3605 -- GEISA Platform Monitoring
+  * ID 3606 -- GEISA Platform Configuration
 
 * ADM conformant platforms shall support the following LWM2M Objects
 
@@ -56,6 +62,9 @@ GEISA Application & Device Management uses the Open Mobile Alliance Lightweight 
   * ID 3600 -- GEISA App Messaging
   * ID 3601 -- GEISA Host Monitoring
   * ID 3602 -- GEISA App Accounting
+  * ID 3604 -- GEISA App Monitoring
+  * ID 3605 -- GEISA Platform Monitoring
+  * ID 3606 -- GEISA Platform Configuration
 
 * ADM conformant platforms with 3GPP network interfaces SHALL support the
   following LWM2M Objects:

--- a/source/references.rst
+++ b/source/references.rst
@@ -25,10 +25,13 @@ References
    <https://www.openmobilealliance.org/release/LightweightM2M/V1_2-20201110-A/OMA-TS-LightweightM2M_Core-V1_2-20201110-A.pdf>`_
 
 .. [RFC2119] `Key words for use in RFCs to Indicate Requirement Levels 
-   <https://www.ietf.org/rfc/rfc2119.txt>`_
+   <https://datatracker.ietf.org/doc/html/rfc2119>`_
 
 .. [RFC7252] `The Constrained Application Protocol (CoAP)
    <https://datatracker.ietf.org/doc/html/rfc7252>`_
+
+.. [RFC9148] `EST-coaps: Enrollment over Secure Transport with the Secure Constrained Application Protocol
+   <https://datatracker.ietf.org/doc/html/rfc9148>`_
 
 
 |geisa-pyramid|


### PR DESCRIPTION
Updated LwM2M section of specification to add clarity to the requirements:

- Added references to the GEISA objects
- Added requirements for EST over CoAP support
- Added references to EST RFCs
