### PR TITLE
Fix versioned specification publishing

### DIFF
--- a/.github/scripts/render-spec-site-index.py
+++ b/.github/scripts/render-spec-site-index.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026, Contributors to the Grid Edge Interoperability & Security Alliance (GEISA), a Series of LF Projects, LLC.
+# This file is licensed under the Community Specification License 1.0 available at:
+# https://github.com/geisa/specification/blob/main/LICENSE.md or
+# https://github.com/CommunitySpecification/Community_Specification/blob/main/1._Community_Specification_License-v1.md
+
+import argparse
+from functools import cmp_to_key
+from datetime import datetime, timezone
+import html
+import json
+import re
+from pathlib import Path
+
+
+SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*))?"
+    r"(?:\+(?P<build>[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*))?$"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render the GEISA specification landing page."
+    )
+    parser.add_argument("--manifest", required=True, help="Path to release manifest JSON.")
+    parser.add_argument("--output", required=True, help="Path to output HTML file.")
+    parser.add_argument(
+        "--latest-built-at",
+        help="ISO-8601 build timestamp for the latest development draft.",
+    )
+    return parser.parse_args()
+
+
+def parse_semver(version: str) -> dict | None:
+    match = SEMVER_RE.fullmatch(version)
+    if not match:
+        return None
+    prerelease = match.group("prerelease")
+    return {
+        "major": int(match.group("major")),
+        "minor": int(match.group("minor")),
+        "patch": int(match.group("patch")),
+        "prerelease": prerelease.split(".") if prerelease else [],
+    }
+
+
+def compare_prerelease_identifiers(left: str, right: str) -> int:
+    left_numeric = left.isdigit()
+    right_numeric = right.isdigit()
+    if left_numeric and right_numeric:
+        return (int(left) > int(right)) - (int(left) < int(right))
+    if left_numeric != right_numeric:
+        return -1 if left_numeric else 1
+    return (left > right) - (left < right)
+
+
+def compare_semver(left_version: str, right_version: str) -> int:
+    left = parse_semver(left_version)
+    right = parse_semver(right_version)
+    if left is None or right is None:
+        return (left_version > right_version) - (left_version < right_version)
+
+    for field in ("major", "minor", "patch"):
+        if left[field] != right[field]:
+            return (left[field] > right[field]) - (left[field] < right[field])
+
+    left_prerelease = left["prerelease"]
+    right_prerelease = right["prerelease"]
+    if not left_prerelease and not right_prerelease:
+        return 0
+    if not left_prerelease:
+        return 1
+    if not right_prerelease:
+        return -1
+
+    for left_identifier, right_identifier in zip(left_prerelease, right_prerelease):
+        compare_result = compare_prerelease_identifiers(left_identifier, right_identifier)
+        if compare_result != 0:
+            return compare_result
+
+    return (len(left_prerelease) > len(right_prerelease)) - (
+        len(left_prerelease) < len(right_prerelease)
+    )
+
+
+def compare_releases(left: dict, right: dict) -> int:
+    return compare_semver(left["version"], right["version"])
+
+
+def load_releases(manifest_path: Path) -> list[dict]:
+    releases = json.loads(manifest_path.read_text(encoding="utf-8"))
+    releases.sort(key=cmp_to_key(compare_releases), reverse=True)
+    return releases
+
+
+def release_label(release: dict) -> str:
+    version = release["version"]
+    match = SEMVER_RE.fullmatch(version)
+    if match and int(match.group("major")) == 0:
+        return "Draft Release"
+    if release.get("prerelease"):
+        return "Prerelease"
+    return "Release"
+
+
+def current_official_release(releases: list[dict]) -> dict | None:
+    return releases[0] if releases else None
+
+
+def parse_iso8601(timestamp: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None
+    return parsed
+
+
+def format_release_date(release: dict) -> str | None:
+    published_at = release.get("published_at")
+    if not published_at:
+        return None
+    published_dt = parse_iso8601(published_at)
+    if published_dt is None:
+        return None
+    return f"Published: {published_dt.strftime('%B')} {published_dt.day}, {published_dt.year}"
+
+
+def format_latest_build_time(latest_built_at: str | None) -> str | None:
+    if not latest_built_at:
+        return None
+    built_dt = parse_iso8601(latest_built_at)
+    if built_dt is None:
+        raise ValueError(f"latest build timestamp must include timezone offset or Z: {latest_built_at}")
+    built_dt = built_dt.astimezone(timezone.utc)
+    return (
+        f"Built: {built_dt.strftime('%B')} {built_dt.day}, {built_dt.year} "
+        f"at {built_dt.strftime('%H:%M')} UTC"
+    )
+
+
+def build_release_items(releases: list[dict]) -> str:
+    if not releases:
+        return (
+            '<li class="release-item">'
+            '<div><strong>No published releases yet</strong>'
+            "<p>Published versioned releases will appear here automatically.</p>"
+            "</div>"
+            "</li>"
+        )
+
+    items = []
+    for release in releases:
+        version = html.escape(release["version"])
+        url = html.escape(release["html_url"])
+        label = html.escape(release_label(release))
+        published_date = format_release_date(release)
+        published_markup = f"<p>{html.escape(published_date)}</p>" if published_date else ""
+        items.append(
+            f"""
+            <li class="release-item">
+              <div>
+                <strong>GEISA Specification {version}</strong>
+                <p>{label} built from tag {html.escape(release["tag_name"])}.</p>
+                {published_markup}
+              </div>
+              <div class="release-links">
+                <a href="./{version}/index.html">HTML</a>
+                <a href="./{version}/downloads/geisaspecification.pdf">PDF</a>
+                <a href="{url}">GitHub release</a>
+              </div>
+            </li>
+            """.strip()
+        )
+    return "\n".join(items)
+
+
+def render_current_panel(release: dict | None) -> str:
+    if release is None:
+        return """
+        <section class="panel" aria-labelledby="current-release-heading">
+          <div class="section-label">Current official release</div>
+          <h2 id="current-release-heading">No published GEISA release yet</h2>
+          <p>
+            Published GitHub releases will appear here automatically after they
+            are released.
+          </p>
+        </section>
+        """.strip()
+
+    current_version = html.escape(release["version"])
+    current_release_url = html.escape(release["html_url"])
+    current_label = html.escape(release_label(release))
+    published_date = format_release_date(release)
+    published_markup = f"\n          <p>{html.escape(published_date)}</p>" if published_date else ""
+    return f"""
+        <section class="panel" aria-labelledby="current-release-heading">
+          <div class="section-label">Current official release</div>
+          <h2 id="current-release-heading">GEISA Specification {current_version} {current_label}</h2>
+          <p>
+            This is the newest published GEISA specification release. It is built
+            from tag {html.escape(release["tag_name"])} and remains fixed while
+            development continues on <code>main</code>.
+          </p>{published_markup}
+          <div class="actions">
+            <a class="button" href="./{current_version}/index.html">Open HTML</a>
+            <a class="button secondary" href="./{current_version}/downloads/geisaspecification.pdf">Download PDF</a>
+            <a class="button secondary" href="{current_release_url}">Release notes</a>
+          </div>
+        </section>
+    """.strip()
+
+
+def render_html(releases: list[dict], latest_built_at: str | None) -> str:
+    current = current_official_release(releases)
+    latest_built_time = format_latest_build_time(latest_built_at)
+    latest_built_markup = (
+        f"\n          <p>{html.escape(latest_built_time)}</p>"
+        if latest_built_time
+        else ""
+    )
+    release_items = build_release_items(releases)
+    current_panel = render_current_panel(current)
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GEISA Specification</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --geisa-blue: #1f5f99;
+      --geisa-blue-dark: #16456f;
+      --geisa-green: #00a885;
+      --text: #1f2933;
+      --muted: #52606d;
+      --border: #d9e2ec;
+      --background: #f5f7fa;
+      --card: #ffffff;
+      --accent-bg: #eef7f4;
+    }}
+
+    * {{
+      box-sizing: border-box;
+    }}
+
+    body {{
+      margin: 0;
+      background: var(--background);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }}
+
+    main {{
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 48px 32px;
+    }}
+
+    .hero {{
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: 0 16px 40px rgba(31, 41, 51, 0.08);
+      padding: clamp(32px, 5vw, 56px);
+    }}
+
+    .brand {{
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      margin-bottom: 24px;
+    }}
+
+    .brand img {{
+      width: clamp(120px, 16vw, 220px);
+      height: auto;
+    }}
+
+    .eyebrow {{
+      color: var(--geisa-blue);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }}
+
+    h1 {{
+      margin: 0.2em 0 0;
+      color: var(--geisa-blue-dark);
+      font-size: clamp(2rem, 5vw, 3.2rem);
+      line-height: 1.05;
+    }}
+
+    h2 {{
+      margin: 6px 0 8px;
+      color: var(--geisa-blue-dark);
+      font-size: clamp(1.45rem, 3vw, 2.1rem);
+    }}
+
+    .summary,
+    .panel p,
+    .release-item p,
+    footer {{
+      color: var(--muted);
+    }}
+
+    .summary {{
+      font-size: 1.1rem;
+      max-width: none;
+    }}
+
+    .sections {{
+      display: grid;
+      gap: 22px;
+      margin-top: 32px;
+    }}
+
+    .panel {{
+      padding: 22px 24px;
+      background: var(--accent-bg);
+      border: 1px solid rgba(0, 168, 133, 0.35);
+      border-left: 6px solid var(--geisa-green);
+      border-radius: 14px;
+    }}
+
+    .section-label {{
+      color: var(--geisa-blue-dark);
+      font-size: 0.82rem;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }}
+
+    .actions {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 18px;
+    }}
+
+    a.button {{
+      display: inline-block;
+      padding: 12px 18px;
+      border-radius: 10px;
+      color: #ffffff;
+      background: var(--geisa-blue);
+      font-weight: 700;
+      text-decoration: none;
+    }}
+
+    a.button.secondary {{
+      color: var(--geisa-blue-dark);
+      background: #e6f0f8;
+    }}
+
+    a.button:hover {{
+      background: var(--geisa-blue-dark);
+    }}
+
+    a.button.secondary:hover {{
+      color: #ffffff;
+    }}
+
+    .release-list {{
+      list-style: none;
+      margin: 18px 0 0;
+      padding: 0;
+      display: grid;
+      gap: 14px;
+    }}
+
+    .release-item {{
+      display: flex;
+      justify-content: space-between;
+      gap: 20px;
+      padding: 16px;
+      background: #fbfcfd;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+    }}
+
+    .release-links {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: flex-start;
+    }}
+
+    .release-links a,
+    .links a {{
+      color: var(--geisa-blue-dark);
+      font-weight: 700;
+      text-decoration: none;
+    }}
+
+    .links {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      gap: 14px;
+      margin-top: 28px;
+    }}
+
+    .link-card {{
+      padding: 16px;
+      background: #fbfcfd;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+    }}
+
+    footer {{
+      margin-top: 28px;
+      font-size: 0.9rem;
+    }}
+
+    @media (max-width: 720px) {{
+      .brand,
+      .release-item {{
+        flex-direction: column;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <section class="hero">
+      <div class="brand">
+        <img src="./assets/geisa-pyramid.svg" alt="GEISA logo">
+        <div>
+          <div class="eyebrow">Grid Edge Interoperability &amp; Security Alliance</div>
+          <h1>GEISA Specification</h1>
+        </div>
+      </div>
+
+      <p class="summary">
+        GEISA defines a consistent, secure, and interoperable computing
+        environment for devices at the edge of the electric grid.
+      </p>
+
+      <div class="sections">
+        {current_panel}
+
+        <section class="panel" aria-labelledby="latest-draft-heading">
+          <div class="section-label">Latest development draft</div>
+          <h2 id="latest-draft-heading">Current unreleased draft</h2>
+          <p>
+            This draft is rebuilt from <code>main</code> on each publication and
+            may include changes newer
+            than the current official release.
+          </p>{latest_built_markup}
+          <div class="actions">
+            <a class="button" href="./latest/index.html">Open HTML</a>
+            <a class="button secondary" href="./latest/downloads/geisaspecification.pdf">Download PDF</a>
+          </div>
+        </section>
+
+        <section class="panel" aria-labelledby="available-releases-heading">
+          <div class="section-label">Available releases</div>
+          <h2 id="available-releases-heading">Published versions</h2>
+          <ul class="release-list">
+            {release_items}
+          </ul>
+        </section>
+      </div>
+
+      <div class="links">
+        <div class="link-card">
+          <a href="https://github.com/geisa">GEISA on GitHub</a>
+          <p>Organization home, repositories, and project materials.</p>
+        </div>
+        <div class="link-card">
+          <a href="https://github.com/geisa/specification">Specification repository</a>
+          <p>Source repository for the latest draft and versioned releases.</p>
+        </div>
+        <div class="link-card">
+          <a href="https://github.com/geisa/schemas">Schemas repository</a>
+          <p>Schema and protobuf definitions for GEISA transactions.</p>
+        </div>
+        <div class="link-card">
+          <a href="https://lfenergy.org/projects/geisa/">LF Energy GEISA project page</a>
+          <p>General project information and LF Energy context.</p>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      Copyright 2025-2026, Contributors to the Grid Edge Interoperability
+      &amp; Security Alliance (GEISA), a Series of LF Projects, LLC.
+    </footer>
+  </main>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    args = parse_args()
+    releases = load_releases(Path(args.manifest))
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        render_html(releases, args.latest_built_at),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/stage-spec-releases.py
+++ b/.github/scripts/stage-spec-releases.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026, Contributors to the Grid Edge Interoperability & Security Alliance (GEISA), a Series of LF Projects, LLC.
+# This file is licensed under the Community Specification License 1.0 available at:
+# https://github.com/geisa/specification/blob/main/LICENSE.md or
+# https://github.com/CommunitySpecification/Community_Specification/blob/main/1._Community_Specification_License-v1.md
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+SEMVER_RE = re.compile(
+    r"^(?P<version>"
+    r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*))?"
+    r"(?:\+(?P<build>[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*))?"
+    r")$"
+)
+RESERVED_VERSIONS = {"latest", "assets", "downloads"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build and stage published GEISA specification releases."
+    )
+    parser.add_argument("--manifest", required=True, help="Path to release manifest JSON.")
+    parser.add_argument("--repo", required=True, help="Path to repository checkout.")
+    parser.add_argument("--pages-dir", required=True, help="Path to Pages staging directory.")
+    parser.add_argument("--work-dir", required=True, help="Temporary directory for worktrees.")
+    return parser.parse_args()
+
+
+def load_manifest(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def parse_iso8601(timestamp: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"invalid ISO-8601 timestamp: {timestamp}") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"timestamp must include timezone offset or Z: {timestamp}")
+    return parsed
+
+
+def normalize_tag(tag_name: str) -> str:
+    match = SEMVER_RE.fullmatch(tag_name.removeprefix("v"))
+    if not match:
+        raise ValueError(
+            f"unsupported release tag {tag_name!r}; expected optional leading 'v' and a semantic version"
+        )
+    return match.group("version")
+
+
+def validate_manifest_entry(entry: object, index: int) -> dict:
+    if not isinstance(entry, dict):
+        raise ValueError(f"manifest entry {index} must be a JSON object")
+
+    required_fields = {"tag_name", "version", "prerelease", "html_url", "published_at"}
+    missing_fields = sorted(required_fields - set(entry))
+    if missing_fields:
+        raise ValueError(f"manifest entry {index} is missing required fields: {', '.join(missing_fields)}")
+
+    for field_name in ("tag_name", "version", "html_url", "published_at"):
+        field_value = entry[field_name]
+        if not isinstance(field_value, str) or not field_value.strip():
+            raise ValueError(f"manifest entry {index} field {field_name!r} must be a non-empty string")
+
+    if not isinstance(entry["prerelease"], bool):
+        raise ValueError(f"manifest entry {index} field 'prerelease' must be a boolean")
+
+    tag_name = entry["tag_name"].strip()
+    version = entry["version"].strip()
+    normalized_version = normalize_tag(tag_name)
+    if normalized_version != version:
+        raise ValueError(
+            f"manifest entry {index} tag/version mismatch: tag {tag_name!r} normalizes to "
+            f"{normalized_version!r}, manifest version is {version!r}"
+        )
+
+    if version in RESERVED_VERSIONS:
+        raise ValueError(f"manifest entry {index} version {version!r} uses reserved site directory name")
+
+    version_path = Path(version)
+    if version_path.name != version or version_path.parts != (version,):
+        raise ValueError(f"manifest entry {index} version {version!r} is not a single safe path component")
+
+    if any(token in version for token in ("/", "\\")) or version in {".", ".."} or ".." in version_path.parts:
+        raise ValueError(f"manifest entry {index} version {version!r} contains path traversal or separators")
+
+    parse_iso8601(entry["published_at"].strip())
+
+    return {
+        "tag_name": tag_name,
+        "version": version,
+        "prerelease": entry["prerelease"],
+        "html_url": entry["html_url"].strip(),
+        "published_at": entry["published_at"].strip(),
+    }
+
+
+def validate_manifest(manifest: object) -> list[dict]:
+    if not isinstance(manifest, list):
+        raise ValueError("release manifest top level must be a JSON list")
+
+    validated_entries: list[dict] = []
+    seen_tags: set[str] = set()
+    seen_versions: set[str] = set()
+
+    for index, entry in enumerate(manifest):
+        validated_entry = validate_manifest_entry(entry, index)
+        tag_name = validated_entry["tag_name"]
+        version = validated_entry["version"]
+
+        if tag_name in seen_tags:
+            raise ValueError(f"duplicate release tag in manifest: {tag_name}")
+        if version in seen_versions:
+            raise ValueError(f"duplicate normalized release version in manifest: {version}")
+
+        seen_tags.add(tag_name)
+        seen_versions.add(version)
+        validated_entries.append(validated_entry)
+
+    return validated_entries
+
+
+def ensure_release_outputs(worktree: Path) -> None:
+    html_index = worktree / "build" / "html" / "index.html"
+    pdf_path = worktree / "build" / "latex" / "geisaspecification.pdf"
+    if not html_index.is_file():
+        raise RuntimeError(f"missing HTML output file {html_index}")
+    if not pdf_path.is_file():
+        raise RuntimeError(f"missing PDF output file {pdf_path}")
+    if pdf_path.stat().st_size == 0:
+        raise RuntimeError(f"empty PDF output file {pdf_path}")
+
+
+def ensure_staged_release_outputs(staged_release_dir: Path) -> None:
+    html_index = staged_release_dir / "index.html"
+    pdf_path = staged_release_dir / "downloads" / "geisaspecification.pdf"
+    if not html_index.is_file():
+        raise RuntimeError(f"missing staged HTML output file {html_index}")
+    if not pdf_path.is_file():
+        raise RuntimeError(f"missing staged PDF output file {pdf_path}")
+    if pdf_path.stat().st_size == 0:
+        raise RuntimeError(f"empty staged PDF output file {pdf_path}")
+
+
+def assert_within_work_dir(work_dir: Path, worktree: Path) -> None:
+    resolved_work_dir = work_dir.resolve()
+    resolved_worktree = worktree.resolve()
+    if resolved_work_dir not in resolved_worktree.parents:
+        raise RuntimeError(f"refusing to clean worktree outside configured work dir: {resolved_worktree}")
+
+
+def assert_within_pages_dir(pages_dir: Path, target: Path) -> None:
+    resolved_pages_dir = pages_dir.resolve()
+    resolved_target = target.resolve(strict=False)
+    if resolved_target != resolved_pages_dir and resolved_pages_dir not in resolved_target.parents:
+        raise RuntimeError(f"refusing to stage outside Pages dir: {resolved_target}")
+
+
+def registered_worktrees(repo: Path, env: dict[str, str]) -> dict[Path, bool]:
+    result = run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+    )
+    worktrees: dict[Path, bool] = {}
+    current_path: Path | None = None
+    is_prunable = False
+    for line in result.stdout.splitlines():
+        if not line:
+            if current_path is not None:
+                worktrees[current_path] = is_prunable
+            current_path = None
+            is_prunable = False
+            continue
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree ")).resolve(strict=False)
+            is_prunable = False
+            continue
+        if line.startswith("prunable "):
+            is_prunable = True
+    if current_path is not None:
+        worktrees[current_path] = is_prunable
+    return worktrees
+
+
+def prune_worktrees(repo: Path, env: dict[str, str]) -> None:
+    run(["git", "worktree", "prune"], cwd=repo, env=env)
+
+
+def cleanup_worktree(repo: Path, work_dir: Path, worktree: Path, env: dict[str, str]) -> None:
+    assert_within_work_dir(work_dir, worktree)
+    worktree = worktree.resolve(strict=False)
+    cleanup_errors: list[str] = []
+    worktrees = registered_worktrees(repo, env)
+    is_registered = worktree in worktrees
+
+    if is_registered and worktree.exists():
+        try:
+            run(["git", "worktree", "remove", "--force", str(worktree)], cwd=repo, env=env)
+        except subprocess.CalledProcessError as exc:
+            cleanup_errors.append(f"git worktree remove failed for {worktree}: {exc}")
+    elif worktree.exists():
+        try:
+            shutil.rmtree(worktree)
+        except OSError as exc:
+            cleanup_errors.append(f"filesystem cleanup failed for {worktree}: {exc}")
+
+    try:
+        if is_registered or not worktree.exists():
+            prune_worktrees(repo, env)
+    except subprocess.CalledProcessError as exc:
+        cleanup_errors.append(f"git worktree prune failed: {exc}")
+
+    if cleanup_errors:
+        raise RuntimeError("; ".join(cleanup_errors))
+
+
+def stage_release(worktree: Path, pages_dir: Path, version: str) -> None:
+    release_dir = pages_dir / version
+    temp_dir = pages_dir / f".{version}.tmp"
+    backup_dir = pages_dir / f".{version}.bak"
+    downloads_dir = temp_dir / "downloads"
+    backup_preserved = False
+    backup_holds_prior_release = False
+
+    assert_within_pages_dir(pages_dir, temp_dir)
+    assert_within_pages_dir(pages_dir, backup_dir)
+    assert_within_pages_dir(pages_dir, release_dir)
+
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir)
+    if backup_dir.exists():
+        shutil.rmtree(backup_dir)
+
+    try:
+        downloads_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(worktree / "build" / "html", temp_dir, dirs_exist_ok=True)
+        shutil.copy2(
+            worktree / "build" / "latex" / "geisaspecification.pdf",
+            downloads_dir / "geisaspecification.pdf",
+        )
+        ensure_staged_release_outputs(temp_dir)
+
+        if release_dir.exists():
+            release_dir.replace(backup_dir)
+            backup_holds_prior_release = True
+        if os.environ.get("GEISA_STAGE_RELEASE_FAIL_INSTALL") == version:
+            raise RuntimeError(f"forced release-directory install failure for {version}")
+        temp_dir.replace(release_dir)
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir)
+            backup_holds_prior_release = False
+    except BaseException as install_error:
+        if backup_holds_prior_release and not release_dir.exists() and backup_dir.exists():
+            try:
+                if os.environ.get("GEISA_STAGE_RELEASE_FAIL_RESTORE") == version:
+                    raise RuntimeError(f"forced release-directory restore failure for {version}")
+                backup_dir.replace(release_dir)
+                backup_holds_prior_release = False
+            except BaseException as restore_error:
+                backup_preserved = True
+                raise RuntimeError(
+                    f"release install failed: {install_error}; "
+                    f"backup restore failed: {restore_error}; "
+                    f"preserved backup: {backup_dir}"
+                ) from install_error
+        raise
+    finally:
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+        if backup_dir.exists() and not (backup_holds_prior_release or backup_preserved):
+            shutil.rmtree(backup_dir)
+
+
+def main() -> None:
+    args = parse_args()
+    repo = Path(args.repo).resolve()
+    pages_dir = Path(args.pages_dir).resolve()
+    work_dir = Path(args.work_dir).resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    releases = validate_manifest(load_manifest(Path(args.manifest)))
+
+    env = os.environ.copy()
+    env["PATH"] = f"{repo / 'venv' / 'bin'}:{repo / '.github' / 'bin'}:{env['PATH']}"
+    build_command = ["make", "clean", "all"]
+    if shutil.which("xvfb-run", path=env["PATH"]):
+        build_command = ["xvfb-run", "-a", "make", "clean", "all"]
+
+    prune_worktrees(repo, env)
+
+    for release in releases:
+        version = release["version"]
+        tag_name = release["tag_name"]
+        worktree = work_dir / version
+        if worktree.exists():
+            cleanup_worktree(repo, work_dir, worktree, env)
+
+        run(
+            ["git", "worktree", "add", "--detach", str(worktree), f"refs/tags/{tag_name}"],
+            cwd=repo,
+            env=env,
+        )
+
+        build_error: BaseException | None = None
+        cleanup_error: BaseException | None = None
+        try:
+            run(build_command, cwd=worktree, env=env)
+            ensure_release_outputs(worktree)
+            stage_release(worktree, pages_dir, version)
+        except BaseException as exc:
+            build_error = exc
+        finally:
+            try:
+                cleanup_worktree(repo, work_dir, worktree, env)
+            except BaseException as exc:
+                cleanup_error = exc
+
+        if build_error is not None:
+            if cleanup_error is not None:
+                print(f"cleanup after build failure also failed: {cleanup_error}", file=sys.stderr)
+            raise build_error
+
+        if cleanup_error is not None:
+            raise cleanup_error
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/spec-publish-pages.yml
+++ b/.github/workflows/spec-publish-pages.yml
@@ -6,6 +6,9 @@
 name: Publish specification site
 
 on:
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 permissions:
@@ -27,8 +30,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Check out repository
+      - name: Check out main branch
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -110,7 +116,39 @@ jobs:
           chmod +x "${GITHUB_WORKSPACE}/.github/bin/drawio"
           echo "${GITHUB_WORKSPACE}/.github/bin" >> "${GITHUB_PATH}"
 
-      - name: Build specification
+      - name: Collect published releases
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            if (!process.env.RUNNER_TEMP) {
+              throw new Error("RUNNER_TEMP is required to write the release manifest");
+            }
+            const releaseManifest =
+              `${process.env.RUNNER_TEMP}/published-releases.json`;
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            const publishedReleases = releases
+              .filter((release) => !release.draft)
+              .map((release) => ({
+                tag_name: release.tag_name,
+                version: release.tag_name.replace(/^v/, ""),
+                prerelease: release.prerelease,
+                html_url: release.html_url,
+                published_at: release.published_at || null,
+              }));
+            fs.writeFileSync(
+              releaseManifest,
+              JSON.stringify(publishedReleases, null, 2),
+            );
+
+      - name: Build latest specification
         run: |
           . venv/bin/activate
           xvfb-run -a make clean all
@@ -119,290 +157,33 @@ jobs:
         run: |
           test -d build/html
           test -s build/latex/geisaspecification.pdf
-          VERSION="$(tr -d '[:space:]' < source/geisa_release.txt)"
-          test -n "${VERSION}"
 
           rm -rf build/pages
           mkdir -p build/pages/latest
-          mkdir -p "build/pages/${VERSION}"
           mkdir -p build/pages/downloads
           mkdir -p build/pages/latest/downloads
-          mkdir -p "build/pages/${VERSION}/downloads"
           mkdir -p build/pages/assets
 
           cp -a build/html/. build/pages/latest/
-          cp -a build/html/. "build/pages/${VERSION}/"
           cp build/latex/geisaspecification.pdf build/pages/downloads/geisaspecification.pdf
           cp build/latex/geisaspecification.pdf build/pages/latest/downloads/geisaspecification.pdf
-          cp build/latex/geisaspecification.pdf "build/pages/${VERSION}/downloads/geisaspecification.pdf"
 
           test -s source/images/geisa-pyramid.svg
           cp source/images/geisa-pyramid.svg build/pages/assets/geisa-pyramid.svg
 
+          . venv/bin/activate
+          python .github/scripts/stage-spec-releases.py \
+            --manifest "${RUNNER_TEMP}/published-releases.json" \
+            --repo "${GITHUB_WORKSPACE}" \
+            --pages-dir "${GITHUB_WORKSPACE}/build/pages" \
+            --work-dir "${RUNNER_TEMP}/geisa-spec-release-worktrees"
+          LATEST_BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          python .github/scripts/render-spec-site-index.py \
+            --manifest "${RUNNER_TEMP}/published-releases.json" \
+            --latest-built-at "${LATEST_BUILT_AT}" \
+            --output build/pages/index.html
+
           touch build/pages/.nojekyll
-
-          cat > build/pages/index.html <<HTML
-          <!doctype html>
-          <html lang="en">
-          <head>
-            <meta charset="utf-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1">
-            <title>GEISA Specification — latest development draft</title>
-            <style>
-              :root {
-                color-scheme: light;
-                --geisa-blue: #1f5f99;
-                --geisa-blue-dark: #16456f;
-                --geisa-green: #00a885;
-                --text: #1f2933;
-                --muted: #52606d;
-                --border: #d9e2ec;
-                --background: #f5f7fa;
-                --card: #ffffff;
-                --warning-bg: #fff7e6;
-                --warning-border: #f0b429;
-              }
-
-              * {
-                box-sizing: border-box;
-              }
-
-              body {
-                margin: 0;
-                background: var(--background);
-                color: var(--text);
-                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-                line-height: 1.5;
-              }
-
-              main {
-                max-width: 1280px;
-                margin: 0 auto;
-                padding: 48px 32px;
-              }
-
-              .hero {
-                background: var(--card);
-                border: 1px solid var(--border);
-                border-radius: 18px;
-                box-shadow: 0 16px 40px rgba(31, 41, 51, 0.08);
-                padding: clamp(32px, 5vw, 56px);
-              }
-
-              .brand {
-                display: flex;
-                align-items: center;
-                gap: 20px;
-                margin-bottom: 24px;
-              }
-
-              .brand img {
-                width: clamp(120px, 16vw, 220px);
-                height: auto;
-              }
-
-              .eyebrow {
-                color: var(--geisa-blue);
-                font-size: 0.82rem;
-                font-weight: 700;
-                letter-spacing: 0.08em;
-                text-transform: uppercase;
-              }
-
-              h1 {
-                margin: 0.2em 0 0;
-                color: var(--geisa-blue-dark);
-                font-size: clamp(2rem, 5vw, 3.2rem);
-                line-height: 1.05;
-              }
-
-              .summary {
-                color: var(--muted);
-                font-size: 1.1rem;
-                max-width: none;
-              }
-
-              .release-panel {
-                margin: 32px 0 18px;
-                padding: 22px 24px;
-                background: #eef7f4;
-                border: 1px solid rgba(0, 168, 133, 0.35);
-                border-left: 6px solid var(--geisa-green);
-                border-radius: 14px;
-              }
-
-              .release-panel .label {
-                color: var(--geisa-blue-dark);
-                font-size: 0.82rem;
-                font-weight: 800;
-                letter-spacing: 0.08em;
-                text-transform: uppercase;
-              }
-
-              .release-panel h2 {
-                margin: 6px 0 8px;
-                color: var(--geisa-blue-dark);
-                font-size: clamp(1.45rem, 3vw, 2.1rem);
-              }
-
-              .release-panel p {
-                margin: 0;
-                color: var(--muted);
-              }
-
-              .release-panel .release-actions {
-                display: flex;
-                flex-wrap: wrap;
-                gap: 12px;
-                margin-top: 18px;
-              }
-
-              .release-panel .disabled {
-                display: inline-block;
-                padding: 12px 18px;
-                border: 1px dashed var(--border);
-                border-radius: 10px;
-                color: var(--muted);
-                background: #ffffff;
-                font-weight: 700;
-              }
-
-              .notice {
-                margin: 28px 0;
-                padding: 18px 20px;
-                background: var(--warning-bg);
-                border: 1px solid var(--warning-border);
-                border-radius: 12px;
-              }
-
-              .notice strong {
-                display: block;
-                margin-bottom: 4px;
-              }
-
-              .actions {
-                display: flex;
-                flex-wrap: wrap;
-                gap: 12px;
-                margin: 28px 0;
-              }
-
-              a.button {
-                display: inline-block;
-                padding: 12px 18px;
-                border-radius: 10px;
-                color: #ffffff;
-                background: var(--geisa-blue);
-                font-weight: 700;
-                text-decoration: none;
-              }
-
-              a.button.secondary {
-                color: var(--geisa-blue-dark);
-                background: #e6f0f8;
-              }
-
-              a.button:hover {
-                background: var(--geisa-blue-dark);
-              }
-
-              a.button.secondary:hover {
-                color: #ffffff;
-              }
-
-              .links {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-                gap: 14px;
-                margin-top: 28px;
-              }
-
-              .link-card {
-                padding: 16px;
-                background: #fbfcfd;
-                border: 1px solid var(--border);
-                border-radius: 12px;
-              }
-
-              .link-card a {
-                color: var(--geisa-blue-dark);
-                font-weight: 700;
-              }
-
-              footer {
-                margin-top: 28px;
-                color: var(--muted);
-                font-size: 0.9rem;
-              }
-            </style>
-          </head>
-          <body>
-            <main>
-              <section class="hero">
-                <div class="brand">
-                  <img src="./assets/geisa-pyramid.svg" alt="GEISA logo">
-                  <div>
-                    <div class="eyebrow">Grid Edge Interoperability &amp; Security Alliance</div>
-                    <h1>GEISA Specification</h1>
-                  </div>
-                </div>
-
-                <p class="summary">
-                  GEISA defines a consistent, secure, and interoperable computing
-                  environment for devices at the edge of the electric grid.
-                </p>
-
-                <section class="release-panel" aria-labelledby="current-release-heading">
-                  <div class="label">Current Release</div>
-                  <h2 id="current-release-heading">Unofficial 0.9 Draft Available</h2>
-                  <p>
-                    The 0.9 <b>draft</b> release of the GEISA specification is now available!  Please check out the latest development draft versions below.  Formal release of 0.9 is still pending.
-                  </p>
-                  <div class="release-actions">
-                    <span class="disabled">Official GEISA 0.9 release pending</span>
-                  </div>
-                </section>
-
-                <div class="notice">
-                  <strong>Latest development draft</strong>
-                  This publication is generated from the current GEISA
-                  specification repository for review and convenience only. It is
-                  not an official approved GEISA release.
-                </div>
-
-                <div class="actions">
-                  <a class="button" href="./latest/index.html">Open the HTML draft</a>
-                  <a class="button secondary" href="./downloads/geisaspecification.pdf">Download the PDF draft</a>
-                </div>
-
-                <div class="links">
-                  <div class="link-card">
-                    <a href="https://github.com/geisa">GEISA on GitHub</a>
-                    <p>Organization home, repositories, and project materials.</p>
-                  </div>
-                  <div class="link-card">
-                    <a href="https://github.com/geisa/specification">Specification repository</a>
-                    <p>Source repository for this development draft.</p>
-                  </div>
-                  <div class="link-card">
-                    <a href="https://github.com/geisa/schemas">Schemas repository</a>
-                    <p>Schema and protobuf definitions for GEISA transactions.</p>
-                  </div>
-                  <div class="link-card">
-                    <a href="https://lfenergy.org/projects/geisa/">LF Energy GEISA project page</a>
-                    <p>General project information and LF Energy context.</p>
-                  </div>
-                </div>
-              </section>
-
-              <footer>
-                Copyright 2025-2026, Contributors to the Grid Edge Interoperability
-                &amp; Security Alliance (GEISA), a Series of LF Projects, LLC.
-              </footer>
-            </main>
-          </body>
-          </html>
-          HTML
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ node_modules
 .markdownlintignore
 package.json
 package-lock.json
+
+# Python bytecode caches
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ outputs.
 
 To build a custom sphinx target, use `SPHINXTARGETS=foo make all`.
 
-NOTE: Running multiple jobs as part of make (`-j4`) may result in errors in the 
+NOTE: Running multiple jobs as part of make (`-j4`) may result in errors in the
 LatexPDF build.  If these occur, use `make all` instead.
 
 NOTE: Depending on your specific distribution, you may encounter errors on the


### PR DESCRIPTION
## Summary

Fixes the GEISA specification publication action and site so published releases
as well as the latest development draft are presented separately and unambiguously
along with release date and build date respectively.

## Changes

- builds `latest/` explicitly from `main`
- rebuilds each versioned release from its associated tag
- preserves original GitHub release publication dates
- displays the current latest build timestamp separately
- generates the site landing page from release metadata
- retains the root PDF compatibility alias for the latest draft for now (no
  embedded version in filename..yet :-/ )
- adds automatic publishing on GitHub Release publishing
- fixes a  minor existing README lint issue

## What it does not do

- does not auto-build on merges or daily, but we can plug that into it later..
