### PR TITLE
Run daily build and publish to spec site at 10:00 UTC/~2am PST.

### DIFF
--- a/.github/workflows/spec-publish-pages.yml
+++ b/.github/workflows/spec-publish-pages.yml
@@ -9,6 +9,9 @@ on:
   release:
     types:
       - published
+  schedule:
+    # 10:00 UTC = ~2am PST ignoring DST changes
+    - cron: "0 10 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- runs the specification publication workflow daily at 08:00 UTC/!2am PST (ignoring DST)
- no changes to the existing published-release and manual triggers
- retains the existing versioned-release, `latest/`, and PDF download paths

## Tracking

- completes Issue #119 