### PR TITLE
api:sensors: change topic for consistency with other topics

### DIFF
--- a/source/api/api-catalog-reference.rst
+++ b/source/api/api-catalog-reference.rst
@@ -334,14 +334,14 @@ API Topic and Permission Catalog
      - ``GeisaSensorReading``
      - Broadcast
    * -
-     - ``geisa/api/sensor-req/<userid>``
+     - ``geisa/api/sensor/req/<userid>``
      - Application
      - Publish
      - App → Platform
      - ``GeisaSensorReadings_Req``
      - Request
    * -
-     - ``geisa/api/sensor-rsp/<userid>``
+     - ``geisa/api/sensor/rsp/<userid>``
      - Application
      - Subscribe
      - Platform → App
@@ -355,14 +355,14 @@ API Topic and Permission Catalog
      - ``GeisaSensorReading``
      - Broadcast
    * -
-     - ``geisa/api/sensor-req/#``
+     - ``geisa/api/sensor/req/#``
      - Platform
      - Wildcard Subscribe
      - App → Platform
      - ``GeisaSensorReadings_Req``
      - Request
    * -
-     - ``geisa/api/sensor-rsp/<userid>``
+     - ``geisa/api/sensor/rsp/<userid>``
      - Platform
      - Publish
      - Platform → App

--- a/source/api/sensors.rst
+++ b/source/api/sensors.rst
@@ -280,8 +280,8 @@ MQTT Details
 
 - QoS: 0 / Unacknowledged
 - Topic: ``geisa/api/sensor``
-- Topic: ``geisa/api/sensor-req/<userid>``
-- Topic: ``geisa/api/sensor-rsp/<userid>``
+- Topic: ``geisa/api/sensor/req/<userid>``
+- Topic: ``geisa/api/sensor/rsp/<userid>``
 
 .. note::
 
@@ -295,14 +295,14 @@ API Permissions
 - Application:
 
   - Subscribe: ``geisa/api/sensor``
-  - Publish: ``geisa/api/sensor-req/<userid>``
-  - Subscribe: ``geisa/api/sensor-rsp/<userid>``
+  - Publish: ``geisa/api/sensor/req/<userid>``
+  - Subscribe: ``geisa/api/sensor/rsp/<userid>``
 
 - Platform:
 
   - Publish: ``geisa/api/sensor``
-  - Subscribe: ``geisa/api/sensor-req/#``
-  - Publish: ``geisa/api/sensor-rsp/<userid>``
+  - Subscribe: ``geisa/api/sensor/req/#``
+  - Publish: ``geisa/api/sensor/rsp/<userid>``
 
 Transaction Data
 ================


### PR DESCRIPTION
All other topics use a slash between the resource and the action, so this change makes the sensor topics consistent with that pattern.